### PR TITLE
(PDB-2185) Remove memory-leak caused by PQL patch

### DIFF
--- a/lib/src/puppetdb-cli.cc
+++ b/lib/src/puppetdb-cli.cc
@@ -84,11 +84,15 @@ void
 pdb_query(const json::JsonContainer& config,
           const string& query) {
     auto curl = pdb_curl_handler(config);
-    const string url_encoded_query = curl_easy_escape(curl.get(), query.c_str(), query.length());
+
+    auto url_encoded_query = unique_ptr< char, function<void(char*)> >(
+        curl_easy_escape(curl.get(), query.c_str(), query.length()),
+        curl_free);
+
     const auto server_url = pdb_server_url(config) +
             "/pdb/query/v4" +
             "?query=" +
-            url_encoded_query;
+            url_encoded_query.get();
 
     curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
     curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, stdout);


### PR DESCRIPTION
This commit makes sure to manage the char\* we get back from url-encoding
the query with a unique_ptr so that we always deallocate the c_str.
