### PR TITLE
(PDB-2340) Separate out Puppet subcommands for db and query

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -14,7 +14,15 @@ include_directories(
     ${LEATHERMAN_JSON_CONTAINER_INCLUDE}
 )
 
-add_executable(puppet-db ${PROJECT_NAME}.cc)
+add_executable(puppet-query puppet-query.cc)
+target_link_libraries(puppet-query
+    lib${PROJECT_NAME}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${LEATHERMAN_LIBRARIES}
+)
+
+add_executable(puppet-db puppet-db.cc)
 target_link_libraries(puppet-db
     lib${PROJECT_NAME}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
@@ -23,7 +31,7 @@ target_link_libraries(puppet-db
     ${LEATHERMAN_JSON_CONTAINER_LIB}
 )
 
-leatherman_install(puppet-db)
+leatherman_install(puppet-query puppet-db)
 
 # Tests for the executable. These don't verify behavior, simply that the
 # executable runs without crashing or generating an error. Useful, but should be
@@ -31,6 +39,8 @@ leatherman_install(puppet-db)
 
 # We duplicate the `help_test` as `smoke_test` until the default functionality
 # of the tool has been nailed down.
-add_test(NAME "smoke_test" COMMAND puppet-db)
-add_test(NAME "help_test" COMMAND puppet-db --help)
-add_test(NAME "version_test" COMMAND puppet-db --version)
+add_test(NAME "db_smoke_test" COMMAND puppet-db)
+add_test(NAME "db_help_test" COMMAND puppet-db --help)
+add_test(NAME "db_version_test" COMMAND puppet-db --version)
+add_test(NAME "query_help_test" COMMAND puppet-query --help)
+add_test(NAME "query_version_test" COMMAND puppet-query --version)

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -1,0 +1,96 @@
+// boost includes are not always warning-clean. Disable warnings that
+// cause problems before including the headers, then re-enable the warnings.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#include <boost/nowide/iostream.hpp>
+#include <boost/nowide/args.hpp>
+#include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#pragma GCC diagnostic pop
+#include <leatherman/logging/logging.hpp>
+#include <puppetdb-cli/puppetdb-cli.hpp>
+
+using namespace std;
+namespace nowide = boost::nowide;
+namespace po = boost::program_options;
+namespace logging = leatherman::logging;
+
+void
+help(po::options_description& global_desc)
+{
+    nowide::cout << "usage: puppet-query [global] query <query>\n\n"
+                 << global_desc << endl;
+}
+
+int
+main(int argc, char **argv) {
+    try {
+        // Fix args on Windows to be UTF-8
+        nowide::args arg_utf8(argc, argv);
+
+        // Setup logging
+        logging::setup_logging(nowide::cerr);
+
+        po::options_description global_options("global options");
+        global_options.add_options()
+                ("help,h", "produce help message")
+                ("log-level,l",
+                 po::value<logging::log_level>()->default_value(logging::log_level::warning,
+                                                                "warn"),
+                 "Set logging level.\n"
+                 "Supported levels are: none, trace, debug, info, warn, error, and fatal.")
+                ("version,v", "print the version and exit");
+
+        po::options_description command_line_options("query subcommand options");
+        command_line_options.add(global_options).add_options()
+                ("query", po::value<string>()->default_value(""),
+                 "query to execute against PuppetDB");
+
+        po::positional_options_description positional_options;
+        positional_options.add("query", 1);
+
+        po::variables_map vm;
+
+        try {
+            po::parsed_options parsed = po::command_line_parser(argc, argv).
+                    options(command_line_options).
+                    positional(positional_options).
+                    run();  // throws on error
+            po::store(parsed, vm);
+
+            if (vm.count("help")) {
+                help(global_options);
+                return EXIT_SUCCESS;
+            }
+
+            if (vm.count("version")) {
+                nowide::cout << puppetdb_cli::version() << endl;
+                return EXIT_SUCCESS;
+            }
+
+            po::notify(vm);
+        } catch (exception& ex) {
+            logging::colorize(nowide::cerr, logging::log_level::error);
+            nowide::cerr << "error: " << ex.what() << "\n" << endl;
+            logging::colorize(nowide::cerr);
+            help(global_options);
+            return EXIT_FAILURE;
+        }
+
+        // Get the logging level
+        const auto lvl = vm["log-level"].as<logging::log_level>();
+        logging::set_level(lvl);
+
+        const auto config = puppetdb_cli::parse_config();
+        const auto query = vm["query"].as<string>();
+        puppetdb_cli::pdb_query(config, query);
+    } catch (exception& ex) {
+        logging::colorize(nowide::cerr, logging::log_level::fatal);
+        nowide::cerr << "unhandled exception: " << ex.what() << "\n" << endl;
+        logging::colorize(nowide::cerr);
+        return EXIT_FAILURE;
+    }
+
+    return logging::error_has_been_logged() ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
This commit separates out a puppet-query and puppet-db command from the
the current code by making two executables, one for querying PuppetDB
and another for administrative database tasks.