### PR TITLE
(maint) Add better config file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,30 @@ Example file to place at `~/.puppetlabs/client-tools/puppetdb.conf`:
 ~~~json
 
     {
-        "default_environment":"prod",
-        "environments":{
-            "prod":{
-                "server_urls":[ "https://alpha-rho.local:8081" ],
-                "ca":"<path to ca.pem>",
-                "cert":"<path to cert .pem>",
-                "key":"<path to private-key .pem>"
-            },
-            "dev":{
-                "server_urls":[ "http://localhost:8080" ]
-            }
-        }
+       "puppetdb":{
+                     "server_urls":"https://alpha-rho.local:8081",
+                     "ca":"<path to ca.pem>",
+                     "cert":"<path to cert .pem>",
+                     "key":"<path to private-key .pem>"
+                  }
+    }
+
+~~~
+
+or to specify multiple PuppetDB servers for failover:
+
+~~~json
+
+    {
+       "puppetdb":{
+                     "server_urls":[
+                                     "https://alpha-rho.local:8081",
+                                     "https://beta-theta.local:8081",
+                                   ],
+                     "ca":"<path to ca.pem>",
+                     "cert":"<path to cert .pem>",
+                     "key":"<path to private-key .pem>"
+                  }
     }
 
 ~~~

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -4,11 +4,12 @@
 set(CMAKE_CXX_FLAGS ${${PROJECT_NAME_UPPER}_CXX_FLAGS})
 
 # Set prefix for logging messages.
-leatherman_logging_namespace("puppetlabs.${PROJECT_NAME}.command")
+leatherman_logging_namespace("puppetlabs.puppetdb.command")
 
 # Setup compiling the executable.
 include_directories(
     ../lib/inc
+    ${CURL_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
     ${LEATHERMAN_LOGGING_INCLUDE}
     ${LEATHERMAN_JSON_CONTAINER_INCLUDE}
@@ -16,7 +17,7 @@ include_directories(
 
 add_executable(puppet-query puppet-query.cc)
 target_link_libraries(puppet-query
-    lib${PROJECT_NAME}
+    libpuppetdb
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${LEATHERMAN_LIBRARIES}
@@ -24,7 +25,7 @@ target_link_libraries(puppet-query
 
 add_executable(puppet-db puppet-db.cc)
 target_link_libraries(puppet-db
-    lib${PROJECT_NAME}
+    libpuppetdb
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${LEATHERMAN_LOGGING_LIB}

--- a/exe/puppet-db.cc
+++ b/exe/puppet-db.cc
@@ -83,7 +83,7 @@ main(int argc, char **argv) {
             po::store(parsed, vm);
 
             if (vm.count("version")) {
-                nowide::cout << puppetdb_cli::version() << endl;
+                nowide::cout << puppetdb::version() << endl;
                 return EXIT_SUCCESS;
             }
 
@@ -132,15 +132,15 @@ main(int argc, char **argv) {
         logging::set_level(lvl);
 
         const auto subcommand = vm["subcommand"].as<string>();
-        const auto config = puppetdb_cli::parse_config();
+        const auto pdb_conn = puppetdb::get_puppetdb("");
         if (subcommand == "export") {
-            puppetdb_cli::pdb_export(config,
-                                     vm["outfile"].as<string>(),
-                                     vm["anonymization"].as<string>());
+            puppetdb::pdb_export(pdb_conn,
+                                 vm["outfile"].as<string>(),
+                                 vm["anonymization"].as<string>());
         } else if (subcommand == "import") {
-            puppetdb_cli::pdb_import(config,
-                                     vm["infile"].as<string>(),
-                                     vm["command-versions"].as<string>());
+            puppetdb::pdb_import(pdb_conn,
+                                 vm["infile"].as<string>(),
+                                 vm["command-versions"].as<string>());
         }
     } catch (exception& ex) {
         logging::colorize(nowide::cerr, logging::log_level::fatal);

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -65,7 +65,7 @@ main(int argc, char **argv) {
             }
 
             if (vm.count("version")) {
-                nowide::cout << puppetdb_cli::version() << endl;
+                nowide::cout << puppetdb::version() << endl;
                 return EXIT_SUCCESS;
             }
 
@@ -82,9 +82,9 @@ main(int argc, char **argv) {
         const auto lvl = vm["log-level"].as<logging::log_level>();
         logging::set_level(lvl);
 
-        const auto config = puppetdb_cli::parse_config();
+        const auto pdb_conn = puppetdb::get_puppetdb("");
         const auto query = vm["query"].as<string>();
-        puppetdb_cli::pdb_query(config, query);
+        puppetdb::pdb_query(pdb_conn, query);
     } catch (exception& ex) {
         logging::colorize(nowide::cerr, logging::log_level::fatal);
         nowide::cerr << "unhandled exception: " << ex.what() << "\n" << endl;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,7 +14,7 @@ configure_file("namespaces.dox.in" "${CMAKE_CURRENT_LIST_DIR}/docs/namespaces.do
 set(CMAKE_CXX_FLAGS ${${PROJECT_NAME_UPPER}_CXX_FLAGS})
 
 # Set prefix for logging messages.
-leatherman_logging_namespace("puppetlabs.${PROJECT_NAME}")
+leatherman_logging_namespace("puppetlabs.puppetdb")
 
 # Setup compiling the library.
 include_directories(
@@ -31,17 +31,17 @@ set(PROJECT_SOURCES "src/${PROJECT_NAME}.cc")
 add_library(libprojectsrc OBJECT ${PROJECT_SOURCES})
 set_target_properties(libprojectsrc PROPERTIES POSITION_INDEPENDENT_CODE true)
 
-add_library(lib${PROJECT_NAME} $<TARGET_OBJECTS:libprojectsrc>)
-set_target_properties(lib${PROJECT_NAME} PROPERTIES VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-target_link_libraries(lib${PROJECT_NAME}
+add_library(libpuppetdb $<TARGET_OBJECTS:libprojectsrc>)
+set_target_properties(libpuppetdb PROPERTIES VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+target_link_libraries(libpuppetdb
     ${Boost_LIBRARIES}
     ${LEATHERMAN_LIBRARIES}
     ${CURL_LIBRARIES}
 )
 
-symbol_exports(lib${PROJECT_NAME} "${CMAKE_CURRENT_LIST_DIR}/inc/${PROJECT_NAME}/export.h")
+symbol_exports(libpuppetdb "${CMAKE_CURRENT_LIST_DIR}/inc/${PROJECT_NAME}/export.h")
 
-leatherman_install(lib${PROJECT_NAME})
+leatherman_install(libpuppetdb)
 install(DIRECTORY inc/${PROJECT_NAME} DESTINATION include)
 
 add_subdirectory(tests)

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -5,25 +5,80 @@
 #pragma once
 
 #include <string>
+#include <curl/curl.h>
 #include "export.h"
 
 #include <leatherman/json_container/json_container.hpp>
 
-namespace puppetdb_cli {
+namespace puppetdb {
+
+/**
+ * Typedef for server_urls.
+ */
+LIBPUPPETDB_EXPORT typedef std::vector<std::string> server_urls_t;
+
+/**
+ * Implements a PuppetDB Connection
+ */
+class LIBPUPPETDB_EXPORT PuppetDBConn  {
+  public:
+    /**
+     * Construct a PuppetDB connection using defaults
+     */
+    PuppetDBConn();
+
+    /**
+     * Construct a PuppetDB connection using a config
+     * @param config JsonContainer of the cli configuration.
+     */
+    PuppetDBConn(const leatherman::json_container::JsonContainer& config);
+
+    ~PuppetDBConn() {}
+
+    /**
+     * Get a server_url from the PuppetDB config
+     * @return the first server_url in the config
+     */
+    std::string getServerUrl() const;
+
+    /**
+     * Get a cURL handle with SSL configuration attached
+     * @return a unique_ptr to a cURL handle
+     */
+    std::unique_ptr<CURL, std::function<void(CURL*)> > getCurlHandle() const;
+
+
+  private:
+    /**
+     * Parse the config for server_urls
+     * @param JsonContainer of your PuppetDB CLI configuration
+     * @return a list of server_urls
+     */
+    server_urls_t parseServerUrls(const leatherman::json_container::JsonContainer& config);
+    /// List of PuppetDB server_urls
+    server_urls_t server_urls_;
+    /// The cacert for SSL connections
+    std::string cacert_;
+    /// The client cert for SSL connections
+    std::string cert_;
+    /// The client key for SSL connections
+    std::string key_;
+};
+
+
 
 /**
  * Query the library version.
  * @return A version string with \<major>.\<minor>.\<patch>
  */
-std::string LIBPUPPETDB_CLI_EXPORT
-version();
+LIBPUPPETDB_EXPORT std::string version();
 
 /**
- * Parse a `puppetdb-cli` config at `~/.pdbrc`.
- * @return A JsonContainer of the config.
+ * Parse a `puppetdb-cli` config file and return a PuppetDB connection.
+ * @param config_path string path to your PuppetDB CLI configuration.
+ * @return PuppetDBConn for connecting to PuppetDB.
  */
-leatherman::json_container::JsonContainer LIBPUPPETDB_CLI_EXPORT
-parse_config();
+LIBPUPPETDB_EXPORT PuppetDBConn get_puppetdb(const std::string& config_path);
 
 /**
  * Query a PuppetDB endpoint for a given config.
@@ -31,9 +86,8 @@ parse_config();
  * @param query string of the query for PuppetDB (can be either AST or PQL syntax).
  * @return This function does not return anything.
  */
-void LIBPUPPETDB_CLI_EXPORT
-pdb_query(const leatherman::json_container::JsonContainer& config,
-          const std::string& query);
+LIBPUPPETDB_EXPORT void pdb_query(const PuppetDBConn& conn,
+                                  const std::string& query);
 
 /**
  * Export a PuppetDB archive for a given config.
@@ -42,10 +96,9 @@ pdb_query(const leatherman::json_container::JsonContainer& config,
  * @param anonymization string of the anonymization to apply to the archive.
  * @return This function does not return anything.
  */
-void LIBPUPPETDB_CLI_EXPORT
-pdb_export(const leatherman::json_container::JsonContainer& config,
-           const std::string& path,
-           const std::string& anonymization);
+LIBPUPPETDB_EXPORT void pdb_export(const PuppetDBConn& conn,
+                                   const std::string& path,
+                                   const std::string& anonymization);
 
 /**
  * Upload a PuppetDB archive to an instance of PuppetDB.
@@ -55,10 +108,8 @@ pdb_export(const leatherman::json_container::JsonContainer& config,
  * versions to use on import.
  * Example: '{"replace_facts":4,"store_report":6,"replace_catalog":7}'
 */
+LIBPUPPETDB_EXPORT void pdb_import(const PuppetDBConn& conn,
+                                   const std::string& infile,
+                                   const std::string& command_versions);
 
-void LIBPUPPETDB_CLI_EXPORT
-pdb_import(const leatherman::json_container::JsonContainer& config,
-           const std::string& infile,
-           const std::string& command_versions);
-
-}  // namespace puppetdb_cli
+}  // namespace puppetdb

--- a/lib/src/puppetdb-cli.cc
+++ b/lib/src/puppetdb-cli.cc
@@ -13,7 +13,7 @@
 #include <puppetdb-cli/version.h>
 #include <puppetdb-cli/puppetdb-cli.hpp>
 
-namespace puppetdb_cli {
+namespace puppetdb {
 
 using namespace std;
 namespace fs = boost::filesystem;
@@ -29,51 +29,85 @@ version()
     return PUPPETDB_CLI_VERSION_WITH_COMMIT;
 }
 
-json::JsonContainer
-parse_config() {
-    const string pdbrc_path
+string
+read_config(const string& config_path) {
+    const string expanded_config_path
     { futil::tilde_expand("~/.puppetlabs/client-tools/puppetdb.conf") };
-    const string default_config_str
-    { "{\"puppetdb\":{\"server_urls\":\"http://127.0.0.1:8080\"}}" };
-    const json::JsonContainer default_config(default_config_str);
-    if (fs::exists(pdbrc_path)) {
-        try {
-            const json::JsonContainer raw_config(futil::read(pdbrc_path));
-            return raw_config
-                    .getWithDefault<json::JsonContainer>("puppetdb", default_config);
-        } catch (exception& ex) {
-            logging::colorize(nowide::cerr, logging::log_level::fatal);
-            nowide::cerr << "error parsing config: "
-                         << ex.what() << "\n"
-                         << "falling back to default configuration" << "\n" << endl;
-            logging::colorize(nowide::cerr);
-            return default_config;
+    return fs::exists(expanded_config_path) ?
+            futil::read(expanded_config_path) : "";
+}
+
+PuppetDBConn
+parse_config(const string& config_content) {
+    const json::JsonContainer raw_config(config_content);
+    const auto puppetdb_conn = raw_config.includes("puppetdb") ?
+            PuppetDBConn(raw_config.get<json::JsonContainer>("puppetdb")):
+            PuppetDBConn();
+    if (puppetdb_conn.getServerUrl().empty()) {
+        throw std::runtime_error { "invalid `server_urls` in configuration" };
+    }
+    return puppetdb_conn;
+}
+
+PuppetDBConn
+get_puppetdb(const string& config_path) {
+    const auto config_content = read_config(config_path);
+    return config_content.empty() ? PuppetDBConn() : parse_config(config_content);
+}
+
+PuppetDBConn::PuppetDBConn() :
+        server_urls_ { { "http://127.0.0.1:8080" } },
+        cacert_ { "" },
+        cert_ { "" },
+        key_ { "" } {};
+
+
+PuppetDBConn::PuppetDBConn(const json::JsonContainer& config) :
+        server_urls_ { parseServerUrls(config) },
+        cacert_ { "" },
+        cert_ { "" },
+        key_ { "" } {
+            if (config.includes("cacert")) {
+                cacert_ = config.get<std::string>("cacert");
+            }
+            if (config.includes("cert")) {
+                cert_ = config.get<std::string>("cert");
+            }
+            if (config.includes("key")) {
+                key_ = config.get<std::string>("key");
+            }};
+
+string PuppetDBConn::getServerUrl() const {
+    return server_urls_.size() ? server_urls_[0] : "";
+}
+
+unique_ptr<CURL, function<void(CURL*)> >
+PuppetDBConn::getCurlHandle() const {
+    auto curl = unique_ptr< CURL, function<void(CURL*)> >(curl_easy_init(),
+                                                          curl_easy_cleanup);
+    if (cacert_ != "") curl_easy_setopt(curl.get(), CURLOPT_CAINFO, cacert_.c_str());
+    if (cert_ != "") curl_easy_setopt(curl.get(), CURLOPT_SSLCERT, cert_.c_str());
+    if (key_ != "") curl_easy_setopt(curl.get(), CURLOPT_SSLKEY, key_.c_str());
+    return curl;
+}
+
+server_urls_t
+PuppetDBConn::parseServerUrls(const json::JsonContainer& config) {
+    if (config.includes("server_urls")) {
+        const auto urls_type = config.type("server_urls");
+        if (urls_type == json::DataType::Array) {
+            return config.get<server_urls_t>("server_urls");
+        } else if (urls_type == json::DataType::String) {
+            return { config.get<string>("server_urls") };
+        } else {
+            return {};
         }
     } else {
-        return default_config;
+        return {"http://127.0.0.1:8080"};
     }
 }
 
-string
-pdb_server_url(const json::JsonContainer& config) {
-    const auto server_urls_datatype = config.type("server_urls");
-    if (server_urls_datatype == json::DataType::Array) {
-        const auto server_urls = config.get< vector<string> >("server_urls");
-        return server_urls.size() ? server_urls[0] : "http://127.0.0.1:8080";
-    } else if (server_urls_datatype == json::DataType::String){
-        return config.get< string >("server_urls");
-    } else {
-        logging::colorize(nowide::cerr, logging::log_level::fatal);
-        nowide::cerr << "error: unrecognized JSON type for key 'server_urls'." << "\n"
-                     << "Please use a JSON array or string."<< "\n"
-                     << "falling back to default configuration" << "\n"<< endl;
-        logging::colorize(nowide::cerr);
-        return "http://127.0.0.1:8080";
-    }
-}
-
-size_t
-write_data(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+size_t write_data(void *ptr, size_t size, size_t nmemb, FILE *stream) {
     const size_t written = fwrite(ptr, size, nmemb, stream);
     return written;
 }
@@ -82,34 +116,17 @@ size_t write_body(char *ptr, size_t size, size_t nmemb, void *userdata){
     return size * nmemb;
 }
 
-unique_ptr<CURL, function<void(CURL*)> >
-pdb_curl_handler(const json::JsonContainer& config) {
-    const auto cacert = config.getWithDefault<string>("cacert", "");
-    const auto cert = config.getWithDefault<string>("cert", "");
-    const auto key = config.getWithDefault<string>("key", "");
-
-    auto curl = unique_ptr< CURL, function<void(CURL*)> >(curl_easy_init(),
-                                                          curl_easy_cleanup);
-
-    if (cacert != "") curl_easy_setopt(curl.get(), CURLOPT_CAINFO, cacert.c_str());
-    if (cert != "") curl_easy_setopt(curl.get(), CURLOPT_SSLCERT, cert.c_str());
-    if (key != "") curl_easy_setopt(curl.get(), CURLOPT_SSLKEY, key.c_str());
-    return curl;
-}
-
 void
-pdb_query(const json::JsonContainer& config,
-          const string& query) {
-    auto curl = pdb_curl_handler(config);
-
+pdb_query(const PuppetDBConn& conn,
+          const string& query_str) {
+    auto curl = conn.getCurlHandle();
     auto url_encoded_query = unique_ptr< char, function<void(char*)> >(
-        curl_easy_escape(curl.get(), query.c_str(), query.length()),
+        curl_easy_escape(curl.get(), query_str.c_str(), query_str.length()),
         curl_free);
 
-    const auto server_url = pdb_server_url(config) +
-            "/pdb/query/v4" +
-            "?query=" +
-            url_encoded_query.get();
+    const auto server_url = conn.getServerUrl()
+            + "/pdb/query/v4?query="
+            + url_encoded_query.get();
 
     curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
     curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, stdout);
@@ -126,11 +143,11 @@ pdb_query(const json::JsonContainer& config,
 }
 
 void
-pdb_export(const json::JsonContainer& config,
+pdb_export(const PuppetDBConn& conn,
            const string& path,
            const string& anonymization) {
-    auto curl = pdb_curl_handler(config);
-    const string server_url = pdb_server_url(config)
+    auto curl = conn.getCurlHandle();
+    const string server_url = conn.getServerUrl()
             + "/pdb/admin/v1/archive?anonymization="
             + anonymization;
     curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
@@ -152,15 +169,15 @@ pdb_export(const json::JsonContainer& config,
     }
 }
 
-void pdb_import(const json::JsonContainer& config,
-                const string& infile,
-                const string& command_versions) {
-    auto curl = pdb_curl_handler(config);
+void
+pdb_import(const PuppetDBConn& conn,
+           const string& infile,
+           const string& command_versions) {
+    auto curl = conn.getCurlHandle();
+    const string server_url = conn.getServerUrl() + "/pdb/admin/v1/archive";
+
     curl_httppost* formpost = NULL;
     curl_httppost* lastptr = NULL;
-
-    const string server_url = pdb_server_url(config) + "/pdb/admin/v1/archive";
-
     curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, "archive",
                  CURLFORM_FILE, infile.c_str(), CURLFORM_END);
     curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, "command_versions",
@@ -187,4 +204,4 @@ void pdb_import(const json::JsonContainer& config,
     curl_formfree(formpost);
 }
 
-}  // puppetdb_cli
+}  // puppetdb

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -10,11 +10,11 @@ include_directories(
 
 set(TEST_CASES ${PROJECT_NAME}.cc)
 
-add_executable(lib${PROJECT_NAME}_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
-target_link_libraries(lib${PROJECT_NAME}_test
+add_executable(libpuppetdb_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
+target_link_libraries(libpuppetdb_test
     ${Boost_LIBRARIES}
     ${LEATHERMAN_LIBRARIES}
     ${CURL_LIBRARIES}
 )
 
-add_test(NAME "unit_tests" COMMAND lib${PROJECT_NAME}_test)
+add_test(NAME "unit_tests" COMMAND libpuppetdb_test)

--- a/lib/tests/puppetdb-cli.cc
+++ b/lib/tests/puppetdb-cli.cc
@@ -3,5 +3,5 @@
 #include <puppetdb-cli/puppetdb-cli.hpp>
 
 SCENARIO("version() returns the version") {
-    REQUIRE(puppetdb_cli::version() == PUPPETDB_CLI_VERSION_WITH_COMMIT);
+    REQUIRE(puppetdb::version() == PUPPETDB_CLI_VERSION_WITH_COMMIT);
 }


### PR DESCRIPTION
This commit removes a bug where the default configuration JSON was in
the incorrect format. This commit also adds the ability to pass in
either a single `server_urls` as a string or an array of `server_urls`
for PuppetDB failover. This commit catches JSON parse errors as well and
warns the user when they are encoutered, falling back to the default
configuration.

This commit also aligns the format of the CLI configuration file with
all of the other PuppetDB configuration files, such that there is now a
single `puppetdb` header where you specify your server_urls and ssl
credentials. We do lose the ability to specify multiple PuppetDB
environments but we'll gain this back we add in the ability to specify
the path to the config file via a command line flag.