### PR TITLE
(maint) Remove command-versions flag from import

### DIFF
--- a/exe/puppet-db.cc
+++ b/exe/puppet-db.cc
@@ -67,9 +67,7 @@ main(int argc, char **argv) {
         po::options_description import_subcommand_options("import subcommand options");
         import_subcommand_options.add_options()
                 ("infile", po::value<string>(),
-                 "the file to import into PuppetDB")
-                ("command-versions", po::value<string>(),
-                 "command versions to use for import");
+                 "the file to import into PuppetDB");
 
         po::variables_map vm;
 
@@ -138,9 +136,7 @@ main(int argc, char **argv) {
                                  vm["outfile"].as<string>(),
                                  vm["anonymization"].as<string>());
         } else if (subcommand == "import") {
-            puppetdb::pdb_import(pdb_conn,
-                                 vm["infile"].as<string>(),
-                                 vm["command-versions"].as<string>());
+            puppetdb::pdb_import(pdb_conn, vm["infile"].as<string>());
         }
     } catch (exception& ex) {
         logging::colorize(nowide::cerr, logging::log_level::fatal);

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -104,12 +104,8 @@ LIBPUPPETDB_EXPORT void pdb_export(const PuppetDBConn& conn,
  * Upload a PuppetDB archive to an instance of PuppetDB.
  * @param config JsonContainer of the CLI configuration.
  * @param infile string path to archive file for upload.
- * @param command_versions string json object containing PuppetDB command
- * versions to use on import.
- * Example: '{"replace_facts":4,"store_report":6,"replace_catalog":7}'
 */
 LIBPUPPETDB_EXPORT void pdb_import(const PuppetDBConn& conn,
-                                   const std::string& infile,
-                                   const std::string& command_versions);
+                                   const std::string& infile);
 
 }  // namespace puppetdb

--- a/lib/src/puppetdb-cli.cc
+++ b/lib/src/puppetdb-cli.cc
@@ -171,8 +171,7 @@ pdb_export(const PuppetDBConn& conn,
 
 void
 pdb_import(const PuppetDBConn& conn,
-           const string& infile,
-           const string& command_versions) {
+           const string& infile) {
     auto curl = conn.getCurlHandle();
     const string server_url = conn.getServerUrl() + "/pdb/admin/v1/archive";
 
@@ -180,8 +179,6 @@ pdb_import(const PuppetDBConn& conn,
     curl_httppost* lastptr = NULL;
     curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, "archive",
                  CURLFORM_FILE, infile.c_str(), CURLFORM_END);
-    curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, "command_versions",
-                 CURLFORM_COPYCONTENTS, command_versions.c_str(), CURLFORM_END);
 
     curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
     curl_easy_setopt(curl.get(), CURLOPT_HTTPPOST, formpost);


### PR DESCRIPTION
PDB imports no longer require a command_versions parameters and instead
parses the import tarball until it finds the metadata.