### PR TITLE
(PDB-2385) Stream parse responses from PuppetDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
     packages:
       - gcc-4.8
       - g++-4.8
+      - curl
+      - libcurl4-openssl-dev
       - libboost-filesystem1.55-dev
       - libboost-program-options1.55-dev
       - libboost-regex1.55-dev

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -104,7 +104,7 @@ main(int argc, char **argv) {
             vm["urls"].as<string>(),
             ssl_creds);
         const auto query = vm["query"].as<string>();
-        puppetdb::pdb_query(pdb_conn, query);
+        puppetdb::pdb_query(pdb_conn, "/pdb/query/v4", query);
     } catch (exception& ex) {
         logging::colorize(nowide::cerr, logging::log_level::fatal);
         nowide::cerr << "unhandled exception: " << ex.what() << "\n" << endl;

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -66,10 +66,10 @@ class LIBPUPPETDB_EXPORT PuppetDBConn  {
     std::string getServerUrl() const;
 
     /**
-     * Get a cURL handle with SSL configuration attached
-     * @return a unique_ptr to a cURL handle
+     * Get the SSLCredentials from the PuppetDB config
+     * @return the SSLCredentials for the PuppetDB connection
      */
-    std::unique_ptr<CURL, std::function<void(CURL*)> > getCurlHandle() const;
+    SSLCredentials getSSLCredentials() const;
 
 
   private:

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -109,6 +109,7 @@ LIBPUPPETDB_EXPORT PuppetDBConn get_puppetdb(const std::string& config_path,
  * @return This function does not return anything.
  */
 LIBPUPPETDB_EXPORT void pdb_query(const PuppetDBConn& conn,
+                                  const std::string& endpoint,
                                   const std::string& query);
 
 /**

--- a/lib/src/puppetdb-cli.cc
+++ b/lib/src/puppetdb-cli.cc
@@ -41,9 +41,8 @@ namespace logging = leatherman::logging;
 const server_urls_t default_server_urls = { "http://127.0.0.1:8080" };
 
 string
-version()
-{
-    LOG_DEBUG("puppetdb-cli version is {1}", PUPPETDB_CLI_VERSION_WITH_COMMIT);
+version() {
+    LOG_DEBUG("puppetdb-cli version is %1%", PUPPETDB_CLI_VERSION_WITH_COMMIT);
     return PUPPETDB_CLI_VERSION_WITH_COMMIT;
 }
 
@@ -115,7 +114,7 @@ PuppetDBConn::PuppetDBConn() :
         server_urls_ { default_server_urls } ,
         cacert_ {},
         cert_ {},
-        key_ {};
+        key_ {} {};
 
 PuppetDBConn::PuppetDBConn(const string& urls,
                            const SSLCredentials& ssl_creds) :
@@ -157,22 +156,6 @@ PuppetDBConn::getCurlHandle() const {
     if (!cert_.empty()) curl_easy_setopt(curl.get(), CURLOPT_SSLCERT, cert_.c_str());
     if (!key_.empty()) curl_easy_setopt(curl.get(), CURLOPT_SSLKEY, key_.c_str());
     return curl;
-}
-
-server_urls_t
-PuppetDBConn::parseServerUrls(const json::JsonContainer& config) {
-    if (config.includes("server_urls")) {
-        const auto urls_type = config.type("server_urls");
-        if (urls_type == json::DataType::Array) {
-            return config.get<server_urls_t>("server_urls");
-        } else if (urls_type == json::DataType::String) {
-            return { config.get<string>("server_urls") };
-        } else {
-            return {};
-        }
-    } else {
-        return {"http://127.0.0.1:8080"};
-    }
 }
 
 template<typename T>
@@ -227,7 +210,7 @@ size_t write_queue(char *ptr, size_t size, size_t nmemb, CURLResponseData& ctx) 
             if (!header.starts_with("HTTP/")) {
                 auto pos = header.find_first_of(':');
                 if (pos == boost::string_ref::npos) {
-                    LOG_WARNING("unexpected HTTP response header: {1}.", header);
+                    LOG_WARNING("unexpected HTTP response header: %1%.", header);
                 } else {
                     auto name = header.substr(0, pos).to_string();
                     boost::trim(name);

--- a/lib/src/puppetdb-cli.cc
+++ b/lib/src/puppetdb-cli.cc
@@ -3,7 +3,20 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <queue>
 
+#include <rapidjson/reader.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/filewritestream.h>
+
+
+#define BOOST_THREAD_PROVIDES_GENERIC_SHARED_MUTEX_ON_WIN
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/lock_types.hpp>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/args.hpp>
@@ -30,7 +43,7 @@ const server_urls_t default_server_urls = { "http://127.0.0.1:8080" };
 string
 version()
 {
-    LOG_DEBUG("puppetdb-cli version is %1%", PUPPETDB_CLI_VERSION_WITH_COMMIT);
+    LOG_DEBUG("puppetdb-cli version is {1}", PUPPETDB_CLI_VERSION_WITH_COMMIT);
     return PUPPETDB_CLI_VERSION_WITH_COMMIT;
 }
 
@@ -146,13 +159,159 @@ PuppetDBConn::getCurlHandle() const {
     return curl;
 }
 
-size_t write_data(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+server_urls_t
+PuppetDBConn::parseServerUrls(const json::JsonContainer& config) {
+    if (config.includes("server_urls")) {
+        const auto urls_type = config.type("server_urls");
+        if (urls_type == json::DataType::Array) {
+            return config.get<server_urls_t>("server_urls");
+        } else if (urls_type == json::DataType::String) {
+            return { config.get<string>("server_urls") };
+        } else {
+            return {};
+        }
+    } else {
+        return {"http://127.0.0.1:8080"};
+    }
+}
+
+class SynchronizedCharQueue {
+  public:
+    char front() {
+        boost::unique_lock<boost::mutex> mlock(mutex_);
+        cond_.wait(mlock, [&]{ return !queue_.empty(); });
+        return queue_.front();
+    }
+
+    char pop() {
+        boost::unique_lock<boost::mutex> mlock(mutex_);
+        cond_.wait(mlock,  [&]{ return !queue_.empty(); });
+        auto item = queue_.front();
+        queue_.pop();
+        return item;
+    }
+
+    void push_range(vector<char>& items) {
+        boost::unique_lock<boost::mutex> mlock(mutex_);
+        for (auto item : items) queue_.push(item);
+        mlock.unlock();
+        cond_.notify_one();
+    }
+
+    void push(char item) {
+        boost::unique_lock<boost::mutex> mlock(mutex_);
+        queue_.push(item);
+        mlock.unlock();
+        cond_.notify_one();
+    }
+
+    int size() { return queue_.size(); }
+
+  private:
+    queue<char> queue_;
+    boost::mutex mutex_;
+    boost::condition_variable cond_;
+};
+
+struct UserData {
+    bool collecting_header;
+    vector<string> headers;
+    string content_type;
+    string error_response;
+    SynchronizedCharQueue stream;
+};
+
+size_t write_queue(char *ptr, size_t size, size_t nmemb, UserData& userdata) {
+    const size_t written = size * nmemb;
+    if (userdata.collecting_header) {
+        if (written == 2 && ptr[0] == '\r' && ptr[1] == '\n') {
+            // We've reached the end of the header
+            userdata.collecting_header = false;
+            return written;
+        } else {
+            boost::string_ref header(ptr, written);
+            userdata.headers.push_back(header.to_string());
+
+            if (!header.starts_with("HTTP/")) {
+                auto pos = header.find_first_of(':');
+                if (pos == boost::string_ref::npos) {
+                    LOG_WARNING("unexpected HTTP response header: {1}.", header);
+                } else {
+                    auto name = header.substr(0, pos).to_string();
+                    boost::trim(name);
+                    if (name == "Content-Type") {
+                        auto value = header.substr(pos + 1).to_string();
+                        boost::trim(value);
+                        userdata.content_type = value;
+                    }
+                }
+            }
+        }
+    } else {
+        vector<char> buffer(ptr, ptr + written);
+        userdata.stream.push_range(buffer);
+    }
+    return written;
+}
+
+size_t write_data(char *ptr, size_t size, size_t nmemb, FILE *stream) {
     const size_t written = fwrite(ptr, size, nmemb, stream);
     return written;
 }
 
 size_t write_body(char *ptr, size_t size, size_t nmemb, void *userdata){
     return size * nmemb;
+}
+
+// SynchronizedCharQueueWrapper is a rapidjson adapter which satisfies the
+// `ReadStream` interface for a rapidjson::Reader. This allows us to parse data
+// from curl as we recieve it.
+class SynchronizedCharQueueWrapper {
+  public:
+    typedef char Ch;
+    SynchronizedCharQueueWrapper(SynchronizedCharQueue& stream) : stream_(stream) {}
+    char Peek() const {
+        int c = Front();
+        return c == char_traits<char>::eof() ? '\0' : static_cast<char>(c);
+    }
+    char Take() {
+        int c = Get();
+        return c == char_traits<char>::eof() ? '\0' : static_cast<char>(c);
+    }
+    size_t Tell() const { return (size_t)stream_.size(); }
+    char* PutBegin() { assert(false); return 0; }
+    void Put(char c) { assert(false); }
+    void Flush() { assert(false); }
+    size_t PutEnd(char* c) { assert(false); return 0; }
+  private:
+    int Front() const { return stream_.front(); }
+    int Get() { return stream_.pop(); }
+    SynchronizedCharQueueWrapper(const SynchronizedCharQueueWrapper&);
+    SynchronizedCharQueueWrapper& operator=(const SynchronizedCharQueueWrapper&);
+    SynchronizedCharQueue& stream_;
+};
+
+void write_pretty(UserData& userdata) {
+    // This will make sure to block until we have parsed the header
+    userdata.stream.front();
+
+    boost::string_ref content_type{ userdata.content_type };
+    if (content_type.starts_with("application/json")) {
+        rapidjson::Reader reader;
+        SynchronizedCharQueueWrapper is(userdata.stream);
+        char writeBuffer[65536];
+        rapidjson::FileWriteStream os(stdout, writeBuffer, sizeof(writeBuffer));
+        rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(os);
+        if (!reader.Parse<rapidjson::kParseValidateEncodingFlag>(is, writer)) {
+            nowide::cerr << "error parsing response" << endl;
+        }
+    } else {
+        int c = userdata.stream.pop();
+        while ( c != char_traits<char>::eof() ) {
+            userdata.error_response += c;
+            c = userdata.stream.pop();
+        }
+    }
 }
 
 void
@@ -167,16 +326,22 @@ pdb_query(const PuppetDBConn& conn,
             + "/pdb/query/v4?query="
             + url_encoded_query.get();
 
+    UserData userdata;
+    userdata.collecting_header = true;
     curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
-    curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, stdout);
-    curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_data);
+    curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &userdata);
+    curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_queue);
+    curl_easy_setopt(curl.get(), CURLOPT_HEADER, 1L);
 
+    boost::thread t1(write_pretty, boost::ref(userdata));
     const CURLcode curl_code = curl_easy_perform(curl.get());
+    userdata.stream.push(char_traits<char>::eof());
+    t1.join();
     long http_code = 0;
     curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &http_code);
     if (!(http_code == 200 && curl_code == CURLE_OK)) {
         logging::colorize(nowide::cerr, logging::log_level::fatal);
-        nowide::cerr << "error: " << curl_easy_strerror(curl_code) << endl;
+        nowide::cerr << "error: " << userdata.error_response << endl;
         logging::colorize(nowide::cerr);
     }
 }

--- a/lib/src/puppetdb-cli.cc
+++ b/lib/src/puppetdb-cli.cc
@@ -153,9 +153,9 @@ unique_ptr<CURL, function<void(CURL*)> >
 PuppetDBConn::getCurlHandle() const {
     auto curl = unique_ptr< CURL, function<void(CURL*)> >(curl_easy_init(),
                                                           curl_easy_cleanup);
-    if (cacert_ != "") curl_easy_setopt(curl.get(), CURLOPT_CAINFO, cacert_.c_str());
-    if (cert_ != "") curl_easy_setopt(curl.get(), CURLOPT_SSLCERT, cert_.c_str());
-    if (key_ != "") curl_easy_setopt(curl.get(), CURLOPT_SSLKEY, key_.c_str());
+    if (!cacert_.empty()) curl_easy_setopt(curl.get(), CURLOPT_CAINFO, cacert_.c_str());
+    if (!cert_.empty()) curl_easy_setopt(curl.get(), CURLOPT_SSLCERT, cert_.c_str());
+    if (!key_.empty()) curl_easy_setopt(curl.get(), CURLOPT_SSLKEY, key_.c_str());
     return curl;
 }
 
@@ -186,7 +186,7 @@ class SynchronizedCharQueue {
     vector<char> pop() {
         boost::unique_lock<boost::mutex> mlock(mutex_);
         cond_.wait(mlock, [&]{ return !queue_.empty(); });
-        auto item = queue_.front();
+        vector<char> item( queue_.front() );
         queue_.pop();
         return item;
     }
@@ -319,8 +319,10 @@ void write_pretty(UserData& userdata) {
             nowide::cerr << "error parsing response" << endl;
         }
     } else {
-        vector<char> buffer = userdata.stream.pop();
-        while (buffer.empty()) buffer = userdata.stream.pop();
+        vector<char> buffer;
+        do {
+            buffer = userdata.stream.pop();
+        } while (buffer.empty());
 
         // We always signal the end with a vector of `{ '\0' }`
         while ( static_cast<int>(buffer[0]) != char_traits<char>::eof() ) {
@@ -332,19 +334,25 @@ void write_pretty(UserData& userdata) {
     }
 }
 
-void
-pdb_query(const PuppetDBConn& conn,
-          const string& query_str) {
-    auto curl = conn.getCurlHandle();
-    const auto server_url = conn.getServerUrl() + "/pdb/query/v4";
-    curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
-
+string
+convert_query_to_post_data(const string& query_str) {
     // If this is PQL then we need to wrap the query in double-quotes, otherwise
     // the query is AST and we leave it alone
     string query_str_copy { query_str };
     boost::trim(query_str_copy);
     const string query = (query_str_copy[0] == '[') ? query_str:"\""+ query_str +"\"";
-    const string post_data = "{\"query\":" + query + "}";
+    return "{\"query\":" + query + "}";
+}
+
+void
+pdb_query(const PuppetDBConn& conn,
+          const string& endpoint,
+          const string& query_str) {
+    auto curl = conn.getCurlHandle();
+    const string server_url = conn.getServerUrl() + endpoint;
+    curl_easy_setopt(curl.get(), CURLOPT_URL, server_url.c_str());
+
+    const string post_data = convert_query_to_post_data(query_str);
     curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDS, post_data.c_str());
 
     auto headers = unique_ptr<curl_slist, function<void(curl_slist*)> >(NULL,
@@ -352,7 +360,6 @@ pdb_query(const PuppetDBConn& conn,
     curl_easy_setopt(curl.get(),
                      CURLOPT_HTTPHEADER,
                      curl_slist_append(headers.get(), "Content-Type: application/json"));
-
 
     UserData userdata;
     userdata.collecting_header = true;
@@ -425,18 +432,26 @@ pdb_import(const PuppetDBConn& conn,
     curl_easy_setopt(curl.get(), CURLOPT_HTTPPOST, formpost);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, write_body);
 
-    boost::nowide::cout << "Importing " << infile << " to PuppetDB..." << endl;
+    nowide::cout << "Importing " << infile << " to PuppetDB..." << endl;
 
     const CURLcode curl_code = curl_easy_perform(curl.get());
-    long http_code = 0;
-    curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &http_code);
+    if (curl_code != CURLE_OK) {
+        logging::colorize(nowide::cerr, logging::log_level::fatal);
+        nowide::cerr << "error connecting to PuppetDB: "
+                     << curl_easy_strerror(curl_code) << endl;
+        logging::colorize(nowide::cerr);
 
-    if (http_code == 200 && curl_code == CURLE_OK) {
-      nowide::cout << "Finished importing " << infile << " to PuppetDB." << endl;
     } else {
-      logging::colorize(nowide::cerr, logging::log_level::fatal);
-      nowide::cerr << "error: " << curl_easy_strerror(curl_code) << endl;
-      logging::colorize(nowide::cerr);
+        long http_code = 0;
+        curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &http_code);
+        if (http_code == 200) {
+            nowide::cout << "Finished importing " << infile << " to PuppetDB." << endl;
+        } else {
+            logging::colorize(nowide::cerr, logging::log_level::fatal);
+            nowide::cerr << "error status " << http_code
+                         << " importing archive to PuppetDB" << endl;
+            logging::colorize(nowide::cerr);
+        }
     }
 
     curl_formfree(formpost);


### PR DESCRIPTION
This commit adds functionality to our CLI which will stream parse the
JSON repsonses and errors from PuppetDB. This allows us to stream
pretty-printed responses and eventually stream tabular responses to the
user.