### PR TITLE
(PDB-2387) Add config flags for SSL auth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,12 @@ pod2man(
   "queries PuppetDB data"
 )
 
+pod2man(
+  ${PROJECT_SOURCE_DIR}/man/puppetdb_conf.pod
+  "puppetdb_conf" 8 share/man
+  "PuppetDB CLI configuration"
+)
+
 # Add other dependencies
 find_package(Boost 1.54 REQUIRED COMPONENTS program_options filesystem)
 find_package(CURL REQUIRED)
@@ -74,7 +80,6 @@ enable_cpplint()
 
 add_cppcheck_dirs("${PROJECT_SOURCE_DIR}/lib" "${PROJECT_SOURCE_DIR}/exe")
 enable_cppcheck()
-
 
 add_test(NAME "db_help_test" COMMAND puppet-db --help)
 add_test(NAME "query_help_test" COMMAND puppet-query --help)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,6 @@ add_cppcheck_dirs("${PROJECT_SOURCE_DIR}/lib" "${PROJECT_SOURCE_DIR}/exe")
 enable_cppcheck()
 
 
-# We duplicate the `help_test` as `smoke_test` until the default functionality
-# of the tool has been nailed down.
-add_test(NAME "db_smoke_test" COMMAND puppet-db)
 add_test(NAME "db_help_test" COMMAND puppet-db --help)
 add_test(NAME "query_help_test" COMMAND puppet-query --help)
 

--- a/exe/puppet-db.cc
+++ b/exe/puppet-db.cc
@@ -22,8 +22,8 @@ help(po::options_description& global_desc,
      po::options_description& import_subcommand_desc,
      ostream& os)
 {
-    os << "usage: puppet-db [global] export [options]\n"
-       << "       puppet-db [global] import [options]\n"
+    os << "usage: puppet-db [global] export <outfile> [options]\n"
+       << "       puppet-db [global] import <infile>\n"
        << global_desc << "\n"
        << export_subcommand_desc << "\n"
        << import_subcommand_desc << endl;
@@ -41,10 +41,11 @@ main(int argc, char **argv) {
         po::options_description global_options("global options");
         global_options.add_options()
                 ("help,h", "produce help message")
-                ("config", po::value<string>()->default_value(""),
-                 "path to use for CLI configuration")
+                ("config,c", po::value<string>()->default_value(
+                    "~/.puppetlabs/client-tools/puppetdb.conf"),
+                 "path to use for cli configuration")
                 ("urls", po::value<string>()->default_value(""),
-                 "urls to use for PuppetDB")
+                 "list of urls for connecting to puppetdb, urls can be comma separated")
                 ("cacert", po::value<string>()->default_value(""),
                  "cacert to use for curl")
                 ("cert", po::value<string>()->default_value(""),
@@ -102,6 +103,8 @@ main(int argc, char **argv) {
             }
 
             if (vm.count("help")) {
+                // if they explicitly wanted a help message, direct the output
+                // to cout and return success
                 help(global_options,
                      export_subcommand_options,
                      import_subcommand_options,

--- a/exe/puppet-db.cc
+++ b/exe/puppet-db.cc
@@ -41,6 +41,16 @@ main(int argc, char **argv) {
         po::options_description global_options("global options");
         global_options.add_options()
                 ("help,h", "produce help message")
+                ("config", po::value<string>()->default_value(""),
+                 "path to use for CLI configuration")
+                ("urls", po::value<string>()->default_value(""),
+                 "urls to use for PuppetDB")
+                ("cacert", po::value<string>()->default_value(""),
+                 "cacert to use for curl")
+                ("cert", po::value<string>()->default_value(""),
+                 "client cert to use for curl")
+                ("key", po::value<string>()->default_value(""),
+                 "client private key to use for curl")
                 ("log-level,l",
                  po::value<logging::log_level>()->default_value(logging::log_level::warning,
                                                                 "warn"),
@@ -152,7 +162,13 @@ main(int argc, char **argv) {
         logging::set_level(lvl);
 
         const auto subcommand = vm["subcommand"].as<string>();
-        const auto pdb_conn = puppetdb::get_puppetdb("");
+        const auto pdb_conn = puppetdb::get_puppetdb(
+            vm["config"].as<string>(),
+            vm["urls"].as<string>(),
+            vm["cacert"].as<string>(),
+            vm["cert"].as<string>(),
+            vm["key"].as<string>());
+
         if (subcommand == "export") {
             puppetdb::pdb_export(pdb_conn,
                                  vm["outfile"].as<string>(),

--- a/exe/puppet-db.cc
+++ b/exe/puppet-db.cc
@@ -165,12 +165,15 @@ main(int argc, char **argv) {
         logging::set_level(lvl);
 
         const auto subcommand = vm["subcommand"].as<string>();
+
+        const puppetdb::SSLCredentials ssl_creds =
+                { vm["cacert"].as<string>(),
+                  vm["cert"].as<string>(),
+                  vm["key"].as<string>() };
         const auto pdb_conn = puppetdb::get_puppetdb(
             vm["config"].as<string>(),
             vm["urls"].as<string>(),
-            vm["cacert"].as<string>(),
-            vm["cert"].as<string>(),
-            vm["key"].as<string>());
+            ssl_creds);
 
         if (subcommand == "export") {
             puppetdb::pdb_export(pdb_conn,

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -35,10 +35,11 @@ main(int argc, char **argv) {
         po::options_description global_options("global options");
         global_options.add_options()
                 ("help,h", "produce help message")
-                ("config", po::value<string>()->default_value(""),
-                 "path to use for CLI configuration")
+                ("config,c", po::value<string>()->default_value(
+                    "~/.puppetlabs/client-tools/puppetdb.conf"),
+                 "path to use for cli configuration")
                 ("urls", po::value<string>()->default_value(""),
-                 "urls to use for PuppetDB")
+                 "urls, `http://foo:8080,http://bar:8080`, to use for puppetdb")
                 ("cacert", po::value<string>()->default_value(""),
                  "cacert to use for curl")
                 ("cert", po::value<string>()->default_value(""),
@@ -70,6 +71,8 @@ main(int argc, char **argv) {
             po::store(parsed, vm);
 
             if (vm.count("help")) {
+                // if they explicitly wanted a help message, direct the output
+                // to cout and return success
                 help(global_options, nowide::cout);
                 return EXIT_SUCCESS;
             }

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -95,12 +95,14 @@ main(int argc, char **argv) {
         const auto lvl = vm["log-level"].as<logging::log_level>();
         logging::set_level(lvl);
 
+        const puppetdb::SSLCredentials ssl_creds =
+                { vm["cacert"].as<string>(),
+                  vm["cert"].as<string>(),
+                  vm["key"].as<string>() };
         const auto pdb_conn = puppetdb::get_puppetdb(
             vm["config"].as<string>(),
             vm["urls"].as<string>(),
-            vm["cacert"].as<string>(),
-            vm["cert"].as<string>(),
-            vm["key"].as<string>());
+            ssl_creds);
         const auto query = vm["query"].as<string>();
         puppetdb::pdb_query(pdb_conn, query);
     } catch (exception& ex) {

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -17,10 +17,10 @@ namespace po = boost::program_options;
 namespace logging = leatherman::logging;
 
 void
-help(po::options_description& global_desc)
+help(po::options_description& global_desc, ostream& os)
 {
-    nowide::cout << "usage: puppet-query [global] query <query>\n\n"
-                 << global_desc << endl;
+    os << "usage: puppet-query [global] query <query>\n\n"
+       << global_desc << endl;
 }
 
 int
@@ -60,7 +60,7 @@ main(int argc, char **argv) {
             po::store(parsed, vm);
 
             if (vm.count("help")) {
-                help(global_options);
+                help(global_options, nowide::cout);
                 return EXIT_SUCCESS;
             }
 
@@ -74,7 +74,7 @@ main(int argc, char **argv) {
             logging::colorize(nowide::cerr, logging::log_level::error);
             nowide::cerr << "error: " << ex.what() << "\n" << endl;
             logging::colorize(nowide::cerr);
-            help(global_options);
+            help(global_options, nowide::cerr);
             return EXIT_FAILURE;
         }
 

--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -35,6 +35,16 @@ main(int argc, char **argv) {
         po::options_description global_options("global options");
         global_options.add_options()
                 ("help,h", "produce help message")
+                ("config", po::value<string>()->default_value(""),
+                 "path to use for CLI configuration")
+                ("urls", po::value<string>()->default_value(""),
+                 "urls to use for PuppetDB")
+                ("cacert", po::value<string>()->default_value(""),
+                 "cacert to use for curl")
+                ("cert", po::value<string>()->default_value(""),
+                 "client cert to use for curl")
+                ("key", po::value<string>()->default_value(""),
+                 "client private key to use for curl")
                 ("log-level,l",
                  po::value<logging::log_level>()->default_value(logging::log_level::warning,
                                                                 "warn"),
@@ -82,7 +92,12 @@ main(int argc, char **argv) {
         const auto lvl = vm["log-level"].as<logging::log_level>();
         logging::set_level(lvl);
 
-        const auto pdb_conn = puppetdb::get_puppetdb("");
+        const auto pdb_conn = puppetdb::get_puppetdb(
+            vm["config"].as<string>(),
+            vm["urls"].as<string>(),
+            vm["cacert"].as<string>(),
+            vm["cert"].as<string>(),
+            vm["key"].as<string>());
         const auto query = vm["query"].as<string>();
         puppetdb::pdb_query(pdb_conn, query);
     } catch (exception& ex) {

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -69,12 +69,6 @@ class LIBPUPPETDB_EXPORT PuppetDBConn  {
 
 
   private:
-    /**
-     * Parse the config for server_urls
-     * @param JsonContainer of your PuppetDB CLI configuration
-     * @return a list of server_urls
-     */
-    server_urls_t parseServerUrls(const leatherman::json_container::JsonContainer& config);
     /// List of PuppetDB server_urls
     server_urls_t server_urls_;
     /// The cacert for SSL connections

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -28,10 +28,30 @@ class LIBPUPPETDB_EXPORT PuppetDBConn  {
     PuppetDBConn();
 
     /**
+     * Construct a PuppetDB connection using only config flags
+     * @param urls string of the urls of PuppetDB.
+     * @param cacert string cacert to use for curl.
+     * @param cert client cert to use for curl.
+     * @param key client private key to use for curl.
+     */
+    PuppetDBConn(const std::string& urls,
+                 const std::string& cacert,
+                 const std::string& cert,
+                 const std::string& key);
+
+    /**
      * Construct a PuppetDB connection using a config
      * @param config JsonContainer of the cli configuration.
+     * @param urls string of the urls of PuppetDB.
+     * @param cacert string cacert to use for curl.
+     * @param cert client cert to use for curl.
+     * @param key client private key to use for curl.
      */
-    PuppetDBConn(const leatherman::json_container::JsonContainer& config);
+    PuppetDBConn(const leatherman::json_container::JsonContainer& config,
+                 const std::string& urls,
+                 const std::string& cacert,
+                 const std::string& cert,
+                 const std::string& key);
 
     ~PuppetDBConn() {}
 
@@ -78,7 +98,11 @@ LIBPUPPETDB_EXPORT std::string version();
  * @param config_path string path to your PuppetDB CLI configuration.
  * @return PuppetDBConn for connecting to PuppetDB.
  */
-LIBPUPPETDB_EXPORT PuppetDBConn get_puppetdb(const std::string& config_path);
+LIBPUPPETDB_EXPORT PuppetDBConn get_puppetdb(const std::string& config_path,
+                                             const std::string& urls,
+                                             const std::string& cacert,
+                                             const std::string& cert,
+                                             const std::string& key);
 
 /**
  * Query a PuppetDB endpoint for a given config.

--- a/lib/inc/puppetdb-cli/puppetdb-cli.hpp
+++ b/lib/inc/puppetdb-cli/puppetdb-cli.hpp
@@ -18,6 +18,18 @@ namespace puppetdb {
 LIBPUPPETDB_EXPORT typedef std::vector<std::string> server_urls_t;
 
 /**
+ * SSL credentials for cURL
+ */
+struct LIBPUPPETDB_EXPORT SSLCredentials {
+    /// cacert string cacert to use for curl.
+    const std::string cacert;
+    /// cert client cert to use for curl.
+    const std::string cert;
+    /// key client private key to use for curl.
+    const std::string key;
+};
+
+/**
  * Implements a PuppetDB Connection
  */
 class LIBPUPPETDB_EXPORT PuppetDBConn  {
@@ -30,28 +42,20 @@ class LIBPUPPETDB_EXPORT PuppetDBConn  {
     /**
      * Construct a PuppetDB connection using only config flags
      * @param urls string of the urls of PuppetDB.
-     * @param cacert string cacert to use for curl.
-     * @param cert client cert to use for curl.
-     * @param key client private key to use for curl.
+     * @param ssl_creds SSLCrendentials ssl auth credentials to use for curl.
      */
     PuppetDBConn(const std::string& urls,
-                 const std::string& cacert,
-                 const std::string& cert,
-                 const std::string& key);
+                 const SSLCredentials& ssl_creds);
 
     /**
      * Construct a PuppetDB connection using a config
      * @param config JsonContainer of the cli configuration.
      * @param urls string of the urls of PuppetDB.
-     * @param cacert string cacert to use for curl.
-     * @param cert client cert to use for curl.
-     * @param key client private key to use for curl.
+     * @param ssl_creds SSLCrendentials ssl auth credentials to use for curl.
      */
     PuppetDBConn(const leatherman::json_container::JsonContainer& config,
                  const std::string& urls,
-                 const std::string& cacert,
-                 const std::string& cert,
-                 const std::string& key);
+                 const SSLCredentials& ssl_creds);
 
     ~PuppetDBConn() {}
 
@@ -90,17 +94,17 @@ LIBPUPPETDB_EXPORT std::string version();
 /**
  * Parse a `puppetdb-cli` config file and return a PuppetDB connection.
  * @param config_path string path to your PuppetDB CLI configuration.
+ * @param urls string of the urls of PuppetDB.
+ * @param ssl_creds SSLCrendentials ssl auth credentials to use for curl.
  * @return PuppetDBConn for connecting to PuppetDB.
  */
 LIBPUPPETDB_EXPORT PuppetDBConn get_puppetdb(const std::string& config_path,
                                              const std::string& urls,
-                                             const std::string& cacert,
-                                             const std::string& cert,
-                                             const std::string& key);
+                                             const SSLCredentials& ssl_creds);
 
 /**
  * Query a PuppetDB endpoint for a given config.
- * @param config JsonContainer of the cli configuration.
+ * @param conn PuppetDBConn of the cli configuration.
  * @param query string of the query for PuppetDB (can be either AST or PQL syntax).
  * @return This function does not return anything.
  */
@@ -109,7 +113,7 @@ LIBPUPPETDB_EXPORT void pdb_query(const PuppetDBConn& conn,
 
 /**
  * Export a PuppetDB archive for a given config.
- * @param config JsonContainer of the cli configuration.
+ * @param conn PuppetDBConn of the cli configuration.
  * @param path string of the file path to which to stream the archive.
  * @param anonymization string of the anonymization to apply to the archive.
  * @return This function does not return anything.

--- a/man/puppet-db.pod
+++ b/man/puppet-db.pod
@@ -36,29 +36,28 @@ Displays version information
       The export action will export a PuppetDB archive from PuppetDB. The
       default location of this archive will be './pdb-export.tgz' relative to
       wherever the command was run from. You can specify a different location to
-      export to using the '--outfile <path>' option. Additionally you can
-      specify what level of anonymization you want for your archive using the
-      '--anonymization <str>' flag, for more information about PuppetDB archive
-      anonymization, consult the documentation at:
+      export as an optional argument. Additionally you can specify what level of
+      anonymization you want for your archive using the '--anonymization <str>'
+      flag, for more information about PuppetDB archive anonymization, consult
+      the documentation at:
       [http://docs.puppetlabs.com/puppetdb/master/anonymization.html]
 
-  $ puppet-db import [options]
-
-      The import action will import a PuppetDB archive to PuppetDB. You can
-      specify the location of the archive with the '--infile <path>' option.
+  $ puppet-db import <path>
+      The import action will import a PuppetDB archive to PuppetDB. You must
+      specify the location of the archive to the import action as a path.
 
 =head1 EXAMPLES
 
     --------------------------------------------------------------------
     Example #1 - Export a PuppetDB archive:
 
-    $ puppet-db export
+    $ puppet-db export ./my-pdb-export.tgz
     Exporting PuppetDB...
-    Finished exporting PuppetDB archive to ./pdb-export.tgz.
+    Finished exporting PuppetDB archive to ./my-pdb-export.tgz.
 
     --------------------------------------------------------------------
     Example #2 - Import a PuppetDB archive:
 
-    $ puppet-db import --infile pdb-export.tgz
-    Importing pdb-export.tgz to PuppetDB...
-    Finished importing pdb-export.tgz to PuppetDB.
+    $ puppet-db import ./my-pdb-export.tgz
+    Importing ./my-pdb-export.tgz to PuppetDB...
+    Finished importing ./my-pdb-export.tgz to PuppetDB.

--- a/man/puppet-db.pod
+++ b/man/puppet-db.pod
@@ -28,6 +28,30 @@ the options specific to that action.
 
 Displays version information
 
+=item B<-c>,B<--config> <path>
+
+Overrides the path for the PuppetDB CLI config. For more information about
+PuppetDB CLI configuration, see puppetdb_conf(8).
+Default: ~/.puppetlabs/client-tools/puppetdb.conf
+
+=item B<--urls> <str>
+
+Overrides the SERVER_URLS setting for the PuppetDB service. These urls points to
+your PuppetDB instances. You can specify multiple urls as a comma-delimitted
+list, 'http://foo:8080,http://bar.com:8080'.
+
+=item B<--cacert> <path>
+
+Overrides the path for the Puppet CA cert.
+
+=item B<--cert> <path>
+
+Overrides the path for the Puppet client cert.
+
+=item B<--key> <path>
+
+Overrides the path for the Puppet client private key.
+
 =back
 
 =head1 ACTIONS
@@ -45,6 +69,10 @@ Displays version information
   $ puppet-db import <path>
       The import action will import a PuppetDB archive to PuppetDB. You must
       specify the location of the archive to the import action as a path.
+
+=head1 SEE ALSO
+
+puppet-db(8), puppetdb_conf(8)
 
 =head1 EXAMPLES
 

--- a/man/puppet-query.pod
+++ b/man/puppet-query.pod
@@ -27,7 +27,35 @@ the options specific to that action.
 
 Displays version information
 
+=item B<-c>,B<--config> <path>
+
+Overrides the path for the PuppetDB CLI config. For more information about
+PuppetDB CLI configuration, see puppetdb_conf(8).
+Default: ~/.puppetlabs/client-tools/puppetdb.conf
+
+=item B<--urls> <str>
+
+Overrides the SERVER_URLS setting for the PuppetDB service. These urls points to
+your PuppetDB instances. You can specify multiple urls as a comma-delimitted
+list, 'http://foo:8080,http://bar.com:8080'.
+
+=item B<--cacert> <path>
+
+Overrides the path for the Puppet CA cert.
+
+=item B<--cert> <path>
+
+Overrides the path for the Puppet client cert.
+
+=item B<--key> <path>
+
+Overrides the path for the Puppet client private key.
+
 =back
+
+=head1 SEE ALSO
+
+puppet-db(8), puppetdb_conf(8)
 
 =head1 EXAMPLES
 

--- a/man/puppetdb_conf.pod
+++ b/man/puppetdb_conf.pod
@@ -1,0 +1,81 @@
+=head1 NAME
+
+puppetdb_conf - PuppetDB CLI configuration files
+
+=head1 SYNOPSIS
+
+~/.puppetlabs/client-tools/puppetdb.conf
+
+=head1 DESCRIPTION
+
+The `puppet-query` and `puppet-db` commands obtain their configuration from the
+following sources in the following order:
+
+=over 4
+
+=item 1. command-line options
+
+=item 2. ~/.puppetlabs/client-tools/puppetdb.conf
+
+=item 3. hardcoded default PuppetDB url, B<http://127.0.0.1:8080>
+
+=back
+
+The configuration file is in JSON format.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<server_urls>
+
+Either a JSON String (for a single url) or Array (for multiple urls) of your
+PuppetDB servers to query or manage via the CLI commands.
+
+=item B<cacert>
+
+Your site's CA certificate.
+
+=item B<cert>
+
+An SSL certificate signed by your site's Puppet CA.
+
+=item B<key>
+
+The private key for that certificate.
+
+=back
+
+=head1 SEE ALSO
+
+puppet-db(8), puppet-query(8)
+
+=head1 EXAMPLES
+
+    --------------------------------------------------------------------
+    Example #1 - Using a single entry in server_urls:
+
+    {
+        "puppetdb": {
+            "server_urls":"https://alpha-rho.local:8081",
+            "cacert":"<path to ca.pem>",
+            "cert":"<path to cert .pem>",
+            "key":"<path to private-key .pem>"
+        }
+    }
+
+
+    --------------------------------------------------------------------
+    Example #2 - Using multiple server_urls:
+
+    {
+        "puppetdb": {
+            "server_urls":[
+                "https://alpha-rho.local:8081",
+                "https://beta-phi.local:8081"
+            ],
+            "cacert":"<path to ca.pem>",
+            "cert":"<path to cert .pem>",
+            "key":"<path to private-key .pem>"
+        }
+    }


### PR DESCRIPTION
This commit allows import and export arguments (specifically infile and
outfile respectively) to be supplied positionally to at the command
line. Whereas before a user would have needed to do

```
    puppet-db import --infile foo
```

They may now do

```
    puppet-db import foo
```

This PR also adds `--urls`, `--cacert/--cert/--key` flags to the global options for the CLI and now makes sure we parse `server_urls` when it's a string.