### PR TITLE
(MAINT) Minor fixup to puppetdb-query help

### DIFF
--- a/exe/puppet-query.cc
+++ b/exe/puppet-query.cc
@@ -19,7 +19,7 @@ namespace logging = leatherman::logging;
 void
 help(po::options_description& global_desc, ostream& os)
 {
-    os << "usage: puppet-query [global] query <query>\n\n"
+    os << "usage: puppet-query [global] <query>\n\n"
        << global_desc << endl;
 }
 


### PR DESCRIPTION
query is listed separately from <query> in the usages section of puppetdb-query help, it should just be <query>