### PR TITLE
(maint) Lock openssl patch version (to 0.7.10) for stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rustc-serialize = "0.3"
 url = "0.5"
 
 [dependencies.openssl]
-version = "0.7"
+version = "0.7.10"
 features = ["tlsv1_2"]
 
 [dependencies.multipart]


### PR DESCRIPTION
Prior to this patch our CI was pull in 0.7.11 of rust-openssl which uses
some unstable Rust features (i.e. require the nightly Rust). This commit
locks the patch version so we don't have to deal with the upgrade yet.