### PR TITLE
(maint) Verify hostnames with OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puppetdb"
-version = "1.0.0"
+version = "1.1.0"
 description = "PuppetDB CLI tool in rust."
 readme = "README.md"
 documentation = "http://puppetlabs.github.io/puppetdb-cli/index.html"
@@ -31,6 +31,9 @@ url = "0.5"
 [dependencies.openssl]
 version = "0.7"
 features = ["tlsv1_2"]
+
+[dependencies.openssl-verify]
+version = "0.1"
 
 [dependencies.multipart]
 version = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate beautician;
 #[macro_use]
 extern crate hyper;
 extern crate openssl;
+extern crate openssl_verify;
 extern crate url;
 extern crate multipart;
 extern crate rustc_serialize;


### PR DESCRIPTION
This commit adds the openssl-verify dependency to the puppetdb-cli which
adds support for verifying hostnames when connecting to PuppetDB over
HTTPS.