### PR TITLE
(PDB-2763) Add man pages for Rust CLI

### DIFF
--- a/man/puppet-db.pod
+++ b/man/puppet-db.pod
@@ -1,0 +1,91 @@
+=head1 NAME
+
+puppet db - manage PuppetDB administrative tasks
+
+=head1 SYNOPSIS
+
+puppet-db [options] <action> [arguments]
+
+=head1 DESCRIPTION
+
+The C<puppet-db> tool allows you to perform PuppetDB administrative tasks such
+as exporting and anonymizing a backup of your PuppetDB or importing a backup to
+a PuppetDB. To learn more about the archive format and these administrative
+tasks in general, consult our documentation at:
+[http://docs.puppetlabs.com/puppetdb/master/anonymization.html]
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-h>,B<--help>
+
+Prints a list of the commands and a brief synopsis of each command. If
+an action is specified, it will print a description of that action and
+the options specific to that action.
+
+=item B<--version>
+
+Displays version information
+
+=item B<-c>,B<--config> <path>
+
+Overrides the path for the PuppetDB CLI config. For more information about
+PuppetDB CLI configuration, see puppetdb_conf(8).
+Default: ~/.puppetlabs/client-tools/puppetdb.conf
+
+=item B<--urls> <str>
+
+Overrides the SERVER_URLS setting for the PuppetDB service. These urls points to
+your PuppetDB instances. You can specify multiple urls as a comma-delimitted
+list, 'http://foo:8080,http://bar.com:8080'.
+
+=item B<--cacert> <path>
+
+Overrides the path for the Puppet CA cert.
+
+=item B<--cert> <path>
+
+Overrides the path for the Puppet client cert.
+
+=item B<--key> <path>
+
+Overrides the path for the Puppet client private key.
+
+=back
+
+=head1 ACTIONS
+
+  $ puppet-db export [options]
+      The export action will export a PuppetDB archive from PuppetDB. The
+      default location of this archive will be './pdb-export.tgz' relative to
+      wherever the command was run from. You can specify a different location to
+      export as an optional argument. Additionally you can specify what level of
+      anonymization you want for your archive using the '--anonymization <str>'
+      flag, for more information about PuppetDB archive anonymization, consult
+      the documentation at:
+      [http://docs.puppetlabs.com/puppetdb/master/anonymization.html]
+
+  $ puppet-db import <path>
+      The import action will import a PuppetDB archive to PuppetDB. You must
+      specify the location of the archive to the import action as a path.
+
+=head1 SEE ALSO
+
+puppet-db(8), puppetdb_conf(8)
+
+=head1 EXAMPLES
+
+    --------------------------------------------------------------------
+    Example #1 - Export a PuppetDB archive:
+
+    $ puppet-db export ./my-pdb-export.tgz
+    Exporting PuppetDB...
+    Finished exporting PuppetDB archive to ./my-pdb-export.tgz.
+
+    --------------------------------------------------------------------
+    Example #2 - Import a PuppetDB archive:
+
+    $ puppet-db import ./my-pdb-export.tgz
+    Importing ./my-pdb-export.tgz to PuppetDB...
+    Finished importing ./my-pdb-export.tgz to PuppetDB.

--- a/man/puppet-query.pod
+++ b/man/puppet-query.pod
@@ -1,0 +1,79 @@
+=head1 NAME
+
+puppet query - perform ad hoc queries against PuppetDB
+
+=head1 SYNOPSIS
+
+puppet-query [options] <query>
+
+=head1 DESCRIPTION
+
+The C<puppet-query> tool allows you to query PuppetDB using either the AST or
+PQL query languages. To read more about the syntax of PuppetDB queries, please
+consult the documentation at:
+[http://docs.puppetlabs.com/puppetdb/master/api/query/v4/pql.html]
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-h>,B<--help>
+
+Prints a list of the commands and a brief synopsis of each command. If
+an action is specified, it will print a description of that action and
+the options specific to that action.
+
+=item B<--version>
+
+Displays version information
+
+=item B<-c>,B<--config> <path>
+
+Overrides the path for the PuppetDB CLI config. For more information about
+PuppetDB CLI configuration, see puppetdb_conf(8).
+Default: ~/.puppetlabs/client-tools/puppetdb.conf
+
+=item B<--urls> <str>
+
+Overrides the SERVER_URLS setting for the PuppetDB service. These urls points to
+your PuppetDB instances. You can specify multiple urls as a comma-delimitted
+list, 'http://foo:8080,http://bar.com:8080'.
+
+=item B<--cacert> <path>
+
+Overrides the path for the Puppet CA cert.
+
+=item B<--cert> <path>
+
+Overrides the path for the Puppet client cert.
+
+=item B<--key> <path>
+
+Overrides the path for the Puppet client private key.
+
+=back
+
+=head1 SEE ALSO
+
+puppet-db(8), puppetdb_conf(8)
+
+=head1 EXAMPLES
+
+  ----------------------------------------------------------------------
+  $ puppet-query "nodes { certname = 'host-1' }"
+
+  [
+   {
+      "catalog_environment": "production",
+      "catalog_timestamp": "2016-01-28T18:26:04.023Z",
+      "certname": "host-0",
+      "deactivated": null,
+      "expired": null,
+      "facts_environment": "production",
+      "facts_timestamp": "2016-01-28T18:26:02.589Z",
+      "latest_report_hash": "2638652161207e7606d7d2461538d2dae883237b",
+      "latest_report_status": "failed",
+      "report_environment": "production",
+      "report_timestamp": "2016-01-28T18:13:02.405Z"
+   }
+  ]

--- a/man/puppetdb_conf.pod
+++ b/man/puppetdb_conf.pod
@@ -1,0 +1,81 @@
+=head1 NAME
+
+puppetdb_conf - PuppetDB CLI configuration files
+
+=head1 SYNOPSIS
+
+~/.puppetlabs/client-tools/puppetdb.conf
+
+=head1 DESCRIPTION
+
+The `puppet-query` and `puppet-db` commands obtain their configuration from the
+following sources in the following order:
+
+=over 4
+
+=item 1. command-line options
+
+=item 2. ~/.puppetlabs/client-tools/puppetdb.conf
+
+=item 3. hardcoded default PuppetDB url, B<http://127.0.0.1:8080>
+
+=back
+
+The configuration file is in JSON format.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<server_urls>
+
+Either a JSON String (for a single url) or Array (for multiple urls) of your
+PuppetDB servers to query or manage via the CLI commands.
+
+=item B<cacert>
+
+Your site's CA certificate.
+
+=item B<cert>
+
+An SSL certificate signed by your site's Puppet CA.
+
+=item B<key>
+
+The private key for that certificate.
+
+=back
+
+=head1 SEE ALSO
+
+puppet-db(8), puppet-query(8)
+
+=head1 EXAMPLES
+
+    --------------------------------------------------------------------
+    Example #1 - Using a single entry in server_urls:
+
+    {
+        "puppetdb": {
+            "server_urls":"https://alpha-rho.local:8081",
+            "cacert":"<path to ca.pem>",
+            "cert":"<path to cert .pem>",
+            "key":"<path to private-key .pem>"
+        }
+    }
+
+
+    --------------------------------------------------------------------
+    Example #2 - Using multiple server_urls:
+
+    {
+        "puppetdb": {
+            "server_urls":[
+                "https://alpha-rho.local:8081",
+                "https://beta-phi.local:8081"
+            ],
+            "cacert":"<path to ca.pem>",
+            "cert":"<path to cert .pem>",
+            "key":"<path to private-key .pem>"
+        }
+    }

--- a/pod2man.sh
+++ b/pod2man.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -ue
+
+if ! test "$#" -eq 1; then
+    >&2 echo "usage: pod2man.sh <outpath>"
+    exit 1
+fi
+
+type -p pod2man &> /dev/null
+test -f "man/puppet-db.pod"
+
+pod2man_helper() {
+    local manfile="$1"
+    local outpath="$2"
+    local center="$3"
+    test -f "man/${manfile}.pod"
+    pod2man --section 8 --release \
+            --center "$center" \
+            --name "$manfile" \
+            "man/${manfile}.pod" "${outpath}/share/man/${manfile}.8"
+}
+
+outpath="$1"
+mkdir -p "${outpath}/share/man"
+pod2man_helper "puppet-db" "$outpath" "manages PuppetDB administrative tasks"
+pod2man_helper "puppet-query" "$outpath" "queries PuppetDB data"
+pod2man_helper "puppetdb_conf" "$outpath" "PuppetDB CLI configuration"


### PR DESCRIPTION
This commit adds the logic for building our manpages using pod2man to
the Cargo build script.