### PR TITLE
(PDB-2815) Look for global configuration file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,15 @@ docopt = "0.6"
 rustc-serialize = "0.3"
 url = "0.5"
 
+[target."cfg(windows)".dependencies]
+winapi = "0.2.4"
+winreg = "0.3.2"
+shell32-sys = "0.1.1"
+ole32-sys = "0.2.0"
+kernel32-sys = "0.2.1"
+advapi32-sys = "0.2.0"
+userenv-sys = "0.2.0"
+
 [dependencies.openssl]
 version = "0.7"
 features = ["tlsv1_2"]

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ you to configure your ssl credentials and the location of your PuppetDB.
 
 By default the tool will use `$HOME/.puppetlabs/client-tools/puppetdb.conf` as
 it's configuration file if it exists. You can also configure a global
-configuration (for all users) in `/etc/puppetlabs/client-tools/puppetdb.conf` to
-fall back to if the per-user configuration is not present.
+configuration (for all users) in `/etc/puppetlabs/client-tools/puppetdb.conf`
+(`C:\ProgramData\puppetlabs\client-tools\puppetdb.conf` on Windows) to fall back
+to if the per-user configuration is not present.
 
 The format of the config file can be deduced from the following example.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ The Rust PuppetDB CLI accepts a `--config=<path_to_config>` flag which allows
 you to configure your ssl credentials and the location of your PuppetDB.
 
 By default the tool will use `$HOME/.puppetlabs/client-tools/puppetdb.conf` as
-it's configuration file if it exists.
+it's configuration file if it exists. You can also configure a global
+configuration (for all users) in `/etc/puppetlabs/client-tools/puppetdb.conf` to
+fall back to if the per-user configuration is not present.
 
 The format of the config file can be deduced from the following example.
 

--- a/man/puppetdb_conf.pod
+++ b/man/puppetdb_conf.pod
@@ -17,7 +17,9 @@ following sources in the following order:
 
 =item 2. ~/.puppetlabs/client-tools/puppetdb.conf
 
-=item 3. hardcoded default PuppetDB url, B<http://127.0.0.1:8080>
+=item 3. /etc/puppetlabs/client-tools/puppetdb.conf
+
+=item 4. hardcoded default PuppetDB url, B<http://127.0.0.1:8080>
 
 =back
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -17,7 +17,7 @@ pub fn post_import(pdb_client: &PdbClient, path: String) -> HyperResult {
     let request = Auth::request(&pdb_client.auth, Method::Post, url);
     let mut multipart = Multipart::from_request(request).unwrap();
     multipart.write_file("archive", &path)
-             .unwrap_or_else(|e| pretty_panic!("Error writing archive to request: {}", e));
+        .unwrap_or_else(|e| pretty_panic!("Error writing archive to request: {}", e));
     multipart.send()
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,12 +29,12 @@ pub struct PdbClient {
 /// has `https` as the scheme.
 fn is_ssl(server_urls: &Vec<String>) -> bool {
     server_urls.into_iter()
-               .any(|url| {
-                   "https" ==
-                   Url::parse(&url)
-                       .unwrap_or_else(|e| pretty_panic!("Error parsing url {:?}: {}", url, e))
-                       .scheme
-               })
+        .any(|url| {
+            "https" ==
+            Url::parse(&url)
+                .unwrap_or_else(|e| pretty_panic!("Error parsing url {:?}: {}", url, e))
+                .scheme
+        })
 }
 
 impl PdbClient {
@@ -152,8 +152,7 @@ impl PdbClient {
                 } else {
                     Err(io::Error::new(io::ErrorKind::Other,
                                        "unable to set default token path, \
-                                        please use the `--token` option directly"
-                    ))
+                                        please use the `--token` option directly"))
                 }
             }
         }
@@ -168,9 +167,9 @@ impl PdbClient {
 
         for server_url in self.server_urls.clone() {
             let req = cli.post(&(server_url + "/pdb/query/v4"))
-                         .body(&req_body)
-                         .header(ContentType::json())
-                         .header(Connection::close());
+                .body(&req_body)
+                .header(ContentType::json())
+                .header(Connection::close());
             let res = Auth::auth_header(&self.auth, req).send();
             if res.is_ok() {
                 return res;
@@ -191,7 +190,7 @@ impl PdbClient {
 
         for server_url in self.server_urls.clone() {
             let req = cli.get(&(server_url.clone() + "/status/v1/services"))
-                             .header(Connection::close());
+                .header(Connection::close());
             let res = Auth::auth_header(&self.auth, req).send();
             map.insert(server_url, build_response_json(res));
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,9 +22,15 @@ pub fn global_config_path() -> String {
     path.set_extension("conf");
     path.to_str().unwrap().to_owned()
 }
+
+#[cfg(windows)]
+use windows;
+
 #[cfg(windows)]
 pub fn global_config_path() -> String {
-    let mut path = PathBuf::from("C:\\ProgramData\\PuppetLabs\\client-tools");
+    let mut path = windows::get_special_folder(&windows::FOLDERID_ProgramData).unwrap();
+    path.push("PuppetLabs");
+    path.push("client-tools");
     path.push("puppetdb");
     path.set_extension("conf");
     path.to_str().unwrap().to_owned()

--- a/src/db.rs
+++ b/src/db.rs
@@ -70,8 +70,8 @@ fn copy_response_to_file(resp: &mut utils::HyperResponse, path: String) {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                         .and_then(|d| d.decode())
-                         .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.decode())
+        .unwrap_or_else(|e| e.exit());
     if args.flag_version {
         println!("puppet-db v{}", VERSION.unwrap_or("unknown"));
         return;
@@ -94,11 +94,11 @@ fn main() {
 
     if args.cmd_export {
         let mut resp = admin::get_export(&client, args.flag_anon)
-                           .unwrap_or_else(|e| pretty_panic!("Failed to connect to server: {}", e));
+            .unwrap_or_else(|e| pretty_panic!("Failed to connect to server: {}", e));
         copy_response_to_file(&mut resp, args.arg_path);
     } else if args.cmd_import {
         let mut resp = admin::post_import(&client, args.arg_path)
-                           .unwrap_or_else(|e| pretty_panic!("Failed to connect to server: {}", e));
+            .unwrap_or_else(|e| pretty_panic!("Failed to connect to server: {}", e));
         utils::assert_status_ok(&mut resp);
     } else if args.cmd_status {
         println!("{}", json::as_pretty_json(&client.status()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,21 @@ extern crate url;
 extern crate multipart;
 extern crate rustc_serialize;
 
+#[cfg(windows)]
+extern crate winapi;
+#[cfg(windows)]
+extern crate winreg;
+#[cfg(windows)]
+extern crate shell32;
+#[cfg(windows)]
+extern crate ole32;
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(windows)]
+extern crate advapi32;
+#[cfg(windows)]
+extern crate userenv;
+
 #[cfg(feature = "puppet-access")]
 extern crate puppet_access;
 
@@ -15,3 +30,45 @@ pub mod net;
 pub mod config;
 pub mod client;
 pub mod admin;
+
+#[cfg(windows)]
+pub mod windows {
+    use winapi::*;
+    use std::io;
+    use std::path::PathBuf;
+    use std::ptr;
+    use std::slice;
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use shell32;
+    use ole32;
+
+    #[allow(non_upper_case_globals)]
+    pub const FOLDERID_ProgramData: GUID = GUID {
+        Data1: 0x62AB5D82,
+        Data2: 0xFDC1,
+        Data3: 0x4DC3,
+        Data4: [0xA9, 0xDD, 0x07, 0x0D, 0x1D, 0x49, 0x5D, 0x97],
+    };
+
+    pub fn get_special_folder(id: &shtypes::KNOWNFOLDERID) -> io::Result<PathBuf> {
+        let mut path = ptr::null_mut();
+        let result;
+
+        unsafe {
+            let code = shell32::SHGetKnownFolderPath(id, 0, ptr::null_mut(), &mut path);
+            if code == 0 {
+                let mut length = 0usize;
+                while *path.offset(length as isize) != 0 {
+                    length += 1;
+                }
+                let slice = slice::from_raw_parts(path, length);
+                result = Ok(OsString::from_wide(slice).into());
+            } else {
+                result = Err(io::Error::from_raw_os_error(code));
+            }
+            ole32::CoTaskMemFree(path as *mut _);
+        }
+        result
+    }
+}

--- a/src/net.rs
+++ b/src/net.rs
@@ -17,14 +17,16 @@ use url::Url;
 
 pub struct OpensslClient(SslContext);
 
-pub fn ssl_context<C>(cacert: C,
-                      cert: Option<C>,
-                      key: Option<C>)
-                      -> Result<OpensslClient, SslError>
+pub fn ssl_context<C>(cacert: C, cert: Option<C>, key: Option<C>) -> Result<OpensslClient, SslError>
     where C: AsRef<Path>
 {
     let mut ctx = SslContext::new(SslMethod::Tlsv1_2).unwrap();
-    try!(ctx.set_cipher_list("DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-CAMELLIA128-SHA:DHE-RSA-AES128-SHA:DHE-RSA-CAMELLIA256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:CAMELLIA128-SHA:AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!RC4:!MD5"));
+    try!(ctx.set_cipher_list("DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:\
+                              DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:\
+                              DHE-RSA-CAMELLIA128-SHA:DHE-RSA-AES128-SHA:\
+                              DHE-RSA-CAMELLIA256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:\
+                              AES256-GCM-SHA384:CAMELLIA128-SHA:AES128-SHA:!aNULL:!eNULL:\
+                              !EXPORT:!DES:!3DES:!RC4:!MD5"));
     try!(ctx.set_CA_file(cacert.as_ref()));
     // TODO should validate both key and cert are set when either one is
     // specified
@@ -44,10 +46,10 @@ impl hyper::net::SslClient for OpensslClient {
         let mut ssl = try!(Ssl::new(&self.0));
         try!(ssl.set_hostname(host));
         let host = host.to_owned();
-        ssl.set_verify_callback(SSL_VERIFY_PEER, move |p, x| openssl_verify::verify_callback(&host, p, x));
+        ssl.set_verify_callback(SSL_VERIFY_PEER,
+                                move |p, x| openssl_verify::verify_callback(&host, p, x));
         SslStream::connect(ssl, stream).map_err(From::from)
     }
-
 }
 
 pub fn ssl_connector<C>(cacert: C, cert: Option<C>, key: Option<C>) -> HttpsConnector<OpensslClient>
@@ -78,13 +80,13 @@ pub enum Auth {
 impl Auth {
     pub fn client(&self) -> Client {
         match self {
-            &Auth::CertAuth{ref cacert, ref cert, ref key } => {
+            &Auth::CertAuth { ref cacert, ref cert, ref key } => {
                 let conn = ssl_connector(Path::new(cacert),
                                          Some(Path::new(cert)),
                                          Some(Path::new(key)));
                 Client::with_connector(conn)
             }
-            &Auth::TokenAuth{ref cacert, ..} => {
+            &Auth::TokenAuth { ref cacert, .. } => {
                 let conn = ssl_connector(Path::new(cacert), None, None);
                 Client::with_connector(conn)
             }
@@ -94,13 +96,13 @@ impl Auth {
 
     pub fn request(&self, method: Method, url: Url) -> Request<Fresh> {
         match self {
-            &Auth::CertAuth{ref cacert, ref cert, ref key } => {
+            &Auth::CertAuth { ref cacert, ref cert, ref key } => {
                 let conn = ssl_connector(Path::new(cacert),
                                          Some(Path::new(cert)),
                                          Some(Path::new(key)));
                 Request::<Fresh>::with_connector(method, url, &conn).unwrap()
             }
-            &Auth::TokenAuth{ref cacert, ref token, ..} => {
+            &Auth::TokenAuth { ref cacert, ref token, .. } => {
                 let conn = ssl_connector(Path::new(cacert), None, None);
                 let mut req = Request::<Fresh>::with_connector(method, url, &conn).unwrap();
                 req.headers_mut().set(XAuthentication(token.clone()));
@@ -112,7 +114,9 @@ impl Auth {
 
     pub fn auth_header<'a>(&self, request_builder: RequestBuilder<'a>) -> RequestBuilder<'a> {
         match self {
-            &Auth::TokenAuth{ ref token, .. } => request_builder.header(XAuthentication(token.clone())),
+            &Auth::TokenAuth { ref token, .. } => {
+                request_builder.header(XAuthentication(token.clone()))
+            }
             _ => request_builder,
         }
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -49,8 +49,8 @@ struct Args {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                         .and_then(|d| d.decode())
-                         .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.decode())
+        .unwrap_or_else(|e| e.exit());
     if args.flag_version {
         println!("puppet-query v{}", VERSION.unwrap_or("unknown"));
         return;
@@ -71,8 +71,8 @@ fn main() {
                                       args.flag_token);
 
     let mut resp = client::PdbClient::new(config)
-                       .query(args.arg_query.unwrap())
-                       .unwrap_or_else(|e| pretty_panic!("Failed to connect to server: {}", e));
+        .query(args.arg_query.unwrap())
+        .unwrap_or_else(|e| pretty_panic!("Failed to connect to server: {}", e));
 
     utils::assert_status_ok(&mut resp);
 


### PR DESCRIPTION
This commit adds the ability to use a global configuration file with the
PuppetDB CLI, which we will fall back to if values in the per-user
config file are missing. This global config file is located at
`/etc/puppetlabs/client-tools/puppetdb.conf` similar to the location for
the global config for the other pe-client-tools.