### PR TITLE
(PDB-2856) Tidy up Windows support for the PuppetDB CLI

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use url::Url;
 
 use multipart::client::Multipart;
-use hyper::header::Connection;
+use hyper::header::{Connection, UserAgent};
 use hyper::method::Method;
 
 use super::client::PdbClient;
@@ -29,6 +29,7 @@ pub fn get_export(pdb_client: &PdbClient, anonymization: String) -> HyperResult 
 
     let req = cli.get(&(server_url + "/pdb/admin/v1/archive"))
         .body(&body)
+        .header(UserAgent("puppetdb-cli".to_owned()))
         .header(Connection::close());
     Auth::auth_header(&pdb_client.auth, req).send()
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -80,7 +80,7 @@ fn main() {
     let path = if let Some(cfg_path) = args.flag_config {
         cfg_path
     } else {
-        let conf_dir = env::home_dir().expect("$HOME directory is not configured");
+        let conf_dir = utils::home_dir();
         config::default_config_path(conf_dir)
     };
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -59,7 +59,7 @@ fn main() {
     let path = if let Some(cfg_path) = args.flag_config {
         cfg_path
     } else {
-        let conf_dir = env::home_dir().expect("$HOME directory is not configured");
+        let conf_dir = utils::home_dir();
         config::default_config_path(conf_dir)
     };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use hyper;
 use std::io::{Read, Write};
+use std::env;
+use std::path::PathBuf;
 
 /// Like `println!` but for stderr.
 #[macro_export]
@@ -35,6 +37,17 @@ pub fn assert_status_ok(response: &mut HyperResponse) {
         if let Err(x) = response.read_to_string(&mut temp) {
             panic!("Unable to read response from server: {}", x);
         }
-        pretty_panic!("Error response from server: {}", temp)
+        pretty_panic!("Error response {} from server: {}", response.status, temp)
     }
+}
+
+#[cfg(windows)]
+pub fn home_dir() -> PathBuf {
+    env::remove_var("HOME".to_string());
+    env::home_dir().expect("$USERPROFILE directory is not configured")
+}
+
+#[cfg(not(windows))]
+pub fn home_dir() -> PathBuf {
+    env::home_dir().expect("$HOME directory is not configured")
 }


### PR DESCRIPTION
Prior to this commit leatherman and std::env::home_dir() had different
ways of finding the home directory on Windows. This commit aligns our
C++ and Rust code by unsetting $HOME before using std::env::home_dir()
from Rust code.