### PR TITLE
(PDB-2957) Remove existing PuppetDB CLI configuration before tests

### DIFF
--- a/acceptance/setup/pe/pre_suite/00_setup_env.rb
+++ b/acceptance/setup/pe/pre_suite/00_setup_env.rb
@@ -86,4 +86,5 @@ end
 step "Install pe-client-tools." do
   host = master
   install_package(host, 'pe-client-tools')
+  on(host, 'rm -rf /etc/puppetlabs/client-tools/puppetdb.conf')
 end


### PR DESCRIPTION
This commit is a temporary measure which removes any previous PuppetDB
CLI configuration before running our acceptance tests.