### PR TITLE
(PDB-2957) Remove whitespace around tokens

### DIFF
--- a/puppet_access/src/lib.rs
+++ b/puppet_access/src/lib.rs
@@ -7,7 +7,7 @@ pub fn read_token(path: String) -> io::Result<String> {
     let mut f = try!(File::open(&path));
     let mut s = String::new();
     try!(f.read_to_string(&mut s));
-    Ok(s)
+    Ok(s.trim().to_owned())
 }
 
 /// Given a `home_dir` (e.g. from `std::env::home_dir()`), returns the default


### PR DESCRIPTION
This commit fixes a bug (that currently only surfaces in Windows testing
but exists for all platforms) where tokens with extra whitespace in the
file will break the HTTP request made from the PuppetDB CLI.