### PR TITLE
(PDB-2940) fix utf8 handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ name = "puppet-query"
 path = "src/query.rs"
 
 [dependencies]
-beautician = "0.1"
 hyper = "0.8"
 docopt = "0.6"
 rustc-serialize = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -164,7 +164,7 @@ impl PdbClient {
 
         let cli = Auth::client(&self.auth);
 
-        let req_body = PdbQueryRequest { query: query_to_json(query_str) }.to_string();
+        let req_body = PdbQueryRequest { query: query_to_json(query_str), pretty: true}.to_string();
 
         for server_url in self.server_urls.clone() {
             let req = cli.post(&(server_url + "/pdb/query/v4"))
@@ -325,6 +325,7 @@ fn with_auth_works() {
 #[derive(RustcEncodable)]
 struct PdbQueryRequest {
     query: json::Json,
+    pretty: bool,
 }
 
 /// A helper struct to make encoding the json for a PDB query request body

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate beautician;
 #[macro_use]
 extern crate hyper;
 extern crate openssl;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,13 +1,11 @@
 extern crate rustc_serialize;
 extern crate docopt;
-extern crate beautician;
 extern crate hyper;
 
 #[macro_use]
 extern crate puppetdb;
 
-use std::env;
-use std::io::{self, Write};
+use std::io::{self, Write, Read, BufReader, BufWriter};
 
 use puppetdb::client;
 use puppetdb::utils;
@@ -77,8 +75,13 @@ fn main() {
     utils::assert_status_ok(&mut resp);
 
     let stdout = io::stdout();
-    let mut handle = stdout.lock();
-    beautician::prettify(&mut resp, &mut handle)
-        .ok()
-        .expect("failed to write response");
+    let handle = stdout.lock();
+
+    let mut buf = [0; 64*1024];
+    let mut reader = BufReader::new(resp);
+    let mut writer = BufWriter::new(handle);
+
+    while reader.read(&mut buf).unwrap() != 0 {
+        writer.write(&mut buf);
+    }
 }


### PR DESCRIPTION
Remove beautician dependency and pass pretty-printed output from the API
straight to stdout. This simplifies the code a bit and gets us around a
beautician bug that caused us to mishandle UTF8 in CLI results.