### PR TITLE
(PDB-3158) Use pretty_panic! for BrokenPipe errors

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -76,5 +76,6 @@ fn main() {
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    io::copy(&mut resp, &mut handle).ok().expect("failed to write response");
+    io::copy(&mut resp, &mut handle)
+        .unwrap_or_else(|e| pretty_panic!("Failed to write response: {}", e));
 }


### PR DESCRIPTION
This commit changes the `puppet-query` subcommand to display a nicer
error when it fails to write the response from a query, for example when
there is a BrokenPipe. Prior to this commit we were spitting a stack
trace with less meaningful output on BrokenPipe errors.

Before:
```
[maint/pull_utility_functions_to_shared_library][~/Projects/puppetdb-cli]$ ./target/debug/puppet-query 'nodes {}' | less
thread 'main' panicked at 'failed to write response', ../src/libcore/option.rs:705
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

After:
```
[maint/pull_utility_functions_to_shared_library][~/Projects/puppetdb-cli]$ ./target/debug/puppet-query 'nodes {}' | less
Failed to write response: Broken pipe (os error 32)
```