### PR TITLE
(QENG-4313) Add beaker-abs dependency for CI.next support

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,5 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+gem "beaker-abs", "~> 0.2"
 gem "beaker-hostgenerator", "~> 0.2"
 gem "beaker", '~> 2.5'
 unless ENV["BEAKER_TYPE"] == 'foss'


### PR DESCRIPTION
This commit adds an acceptance testing Gemfile dependency on the beaker-abs gem,
which is necessary in order for the pipeline to run on CI.next.

----

We've had a successful run of the pipeline with this change, which can be seen here: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-client-tools/