### PR TITLE
(PE-18967) Add PE_FAMILY env for acceptance tests

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -22,7 +22,7 @@ end
 desc 'Check the redis version if Jenkins'
 task :check_redis_pe_ver do
   if !ENV['BEAKER_PE_VER']
-    ENV['BEAKER_PE_VER'] = `redis-cli -h redis.delivery.puppetlabs.net get 2016.3_pe_version`.strip
+    ENV['BEAKER_PE_VER'] = `redis-cli -h redis.delivery.puppetlabs.net get #{ENV['PE_FAMILY']}_pe_version`.strip
   else
     warn 'BEAKER_PE_VER already set, skipping check with redis'
   end
@@ -37,7 +37,7 @@ task :acceptance do
   fail "SHA must be set in order to setup repositories!!!" if !ENV['SHA']
 
   # hardcode the pe_dir into the repo instead of the jenkins job
-  ENV['BEAKER_PE_DIR'] = 'http://neptune.puppetlabs.lan/2016.3/ci-ready' unless ENV["BEAKER_TYPE"] == 'foss'
+  ENV['BEAKER_PE_DIR'] = "http://enterprise.delivery.puppetlabs.net/#{ENV['PE_FAMILY']}/ci-ready" unless ENV["BEAKER_TYPE"] == 'foss'
 
   config = ENV["BEAKER_CONFIG"] || 'hosts.cfg'
   preserve_hosts = ENV["BEAKER_PRESERVEHOSTS"] || 'onfail'
@@ -83,11 +83,12 @@ namespace :ci do
 
       t.add_env(:name => 'SHA',           :message => 'The sha for pe-client-tools')
       t.add_env(:name => 'SUITE_VERSION', :message => 'The suite version used by Jenkins')
+      t.add_env(:name => 'PE_FAMILY',     :message => 'The puppet enterprise major branch to install from')
 
       t.add_env do |env|
         env.name = 'pe_dist_dir'
         env.message = 'The location to download PE from example "http://neptune.puppetlabs.lan/20XX.X/ci-ready"'
-        env.default = 'http://neptune.puppetlabs.lan/2016.3/ci-ready'
+        ENV['pe_dist_dir'] ||= "http://neptune.puppetlabs.lan/#{ENV['PE_FAMILY']}/ci-ready"
       end
 
       t.add_command({:name => 'beaker', :override_env => 'BEAKER_EXECUTABLE'})


### PR DESCRIPTION
This commit adds a `PE_FAMILY` environment variable to be used in
the creation of the `pe_dist_dir` and `pe_ver` values. The existing
default value for `pe_dist_dir` has been removed. This means that the
`PE_FAMILY` value must be set by the Jenkins job or the rake task will fail.