### PR TITLE
(QENG-4283) Make Beaker hosts file configurable

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -2,6 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem "beaker-hostgenerator", "~> 0.2"
 gem "beaker", '~> 2.5'
+gem 'beaker-abs', '~> 0.2'
 unless ENV["BEAKER_TYPE"] == 'foss'
   gem 'beaker-pe', '~> 0.9'
   gem 'scooter', '~> 3.2', :require => false

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -72,7 +72,7 @@ namespace :ci do
           {:name => '--xml', :is_boolean => true},
           {:name => '--no-color', :is_boolean => true},
           {:name => '--debug', :is_boolean => true},
-          {:name => '--hosts', :override_env => 'TEST_TARGET'},
+          {:name => '--hosts', :override_env => 'BEAKER_HOSTS'},
           {:name => '--preserve-hosts', :default => 'onfail', :override_env => 'BEAKER_PRESERVEHOSTS'},
           {:name => '--keyfile', :default => "#{ENV['HOME']}/.ssh/id_rsa-acceptance", :override_env => 'BEAKER_KEYFILE'},
           {:name => '--pre-suite', :default => 'pe/setup/pre_suite', :override_env => 'BEAKER_PRESUITE'},
@@ -94,11 +94,13 @@ namespace :ci do
     end
 
     task :set_test_target do
-      client = ENV['CLIENT_TEST_TARGET'] || (fail 'The environment variable CLIENT_TEST_TARGET must be set.')
-      # process the CLIENT_TEST_TARGET variable and assign it to TEST_TARGET so that rototiller will pick it up
-      monolithic_config = "#{client}client.mdca"
-      master_agent_config = "centos7-64.mdca-#{client}client.a"
-      ENV['TEST_TARGET'] ||= (client =~ /win|osx/) ? master_agent_config : monolithic_config
+      if ENV['BEAKER_HOSTS'].nil?
+        client = ENV['CLIENT_TEST_TARGET'] || (fail 'The environment variable CLIENT_TEST_TARGET must be set.')
+        # process the CLIENT_TEST_TARGET variable and assign it to TEST_TARGET so that rototiller will pick it up
+        monolithic_config = "#{client}client.mdca"
+        master_agent_config = "centos7-64.mdca-#{client}client.a"
+        ENV['BEAKER_HOSTS'] ||= (client =~ /win|osx/) ? master_agent_config : monolithic_config
+      end
     end
 
   end


### PR DESCRIPTION
Prior to this commit, only the client test target was configurable when running
the acceptance tests. The master test target was hardcoded, and the vmpooler
hypervisor was always used by Beaker (by virtue of not specifying a hypervisor,
resulting the in the default vmpooler one).

In order to run in CI.next though, all test targets must be known ahead of time,
and the ABS hypervisor must be used by Beaker.

This commit allows for a pre-generated Beaker hosts file to be used, by
specifying it as the value of the BEAKER_HOSTS environment variable.

If BEAKER_HOSTS is not defined, the original behavior will be used.