### PR TITLE
(maint) Update version to 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "puppetdb"
-version = "1.3.0"
+version = "1.2.2"
 dependencies = [
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puppetdb"
-version = "1.3.0"
+version = "1.2.2"
 description = "PuppetDB CLI tool in rust."
 readme = "README.md"
 documentation = "http://puppetlabs.github.io/puppetdb-cli/index.html"


### PR DESCRIPTION
Version 1.2.1 was previously released reporting 1.3.0. The actual
changes were only bug fixes, so continuing in the 1.2 line with 1.2.2.