### PR TITLE
Move common arguments to query and db commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,7 @@ Metrics/BlockLength:
     - puppetdb_cli.gemspec
 Metrics/LineLength:
   Max: 120
+Metrics/MethodLength:
+  Max: 20
+Metrics/AbcSize:
+  Max: 20

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@
 > **Note**: This repository is still under active development. Stay tuned for
 > release dates and functionality changes.
 
-The PuppetDB CLI project provide Puppet subcommands for querying PuppetDB data,
+The PuppetDB CLI project provides Puppet subcommands for querying PuppetDB data,
 via `puppet query <query>`, and PuppetDB administrative tasks, `puppet db
 <import|export|status>`. The `query` subcommand will allow you to query PuppetDB
-using either the upcoming PQL syntax of the traditional PuppetDB query syntax
-(also known as AST). The `db` subcommand is a replacement for the older
+using either PQL or AST syntax. The `db` subcommand is a replacement for the older
 `puppetdb <export|import>` commands with faster startup times and much
 friendlier error messages.
 
@@ -22,30 +21,27 @@ and greater.
 
 ## Installation
 
-Please see
-[the PuppetDB documentation](https://docs.puppet.com/puppetdb/latest/pdb_client_tools.html)
-for instructions on how to install the `puppet-client-tools` package.
+### Prerequisites
 
-## Installation from source
+* Ruby
 
-Using `rustc` and `cargo` (stable, beta, or nightly):
+### Installation from rubygems
+
+The PuppetDB CLI can be installed via a `gem install`.
 
 ```bash
-
-  $ export PATH=./target/debug:$PATH
-  $ cargo build
-  
+gem install --bindir /opt/puppetlabs/bin puppetdb_cli
 ```
 
-When building on OSX or Windows you will also need to install openssl and use
-that for building the PuppetDB CLI. For OSX users the simplest way to do this is
-using Homebrew and running the following commands before the `cargo build`:
+If the machine does not have Puppet installed, you can simply use `gem install puppetdb_cli`
+and use the `puppet-query` and `puppet-db` executables directly.
+
+### Installation from source
+
+From the cloned repository
 
 ```bash
-
-  $ export OPENSSL_LIB_DIR=$(brew --prefix)/lib
-  $ export OPENSSL_INCLUDE_DIR=$(brew --prefix)/include
-
+bundle exec rake install
 ```
 
 ## Usage
@@ -53,7 +49,6 @@ using Homebrew and running the following commands before the `cargo build`:
 Example usage:
 
 ```bash
-
 $ puppet-query 'nodes[certname]{}'
 [
   {
@@ -88,7 +83,6 @@ $ puppet-db status
     "status": {}
   }
 }
-
 ```
 
 ## Configuration

--- a/lib/puppetdb_cli.rb
+++ b/lib/puppetdb_cli.rb
@@ -19,32 +19,6 @@ module PuppetDBCLI
     summary 'PuppetDB CLI'
     description 'A command line tool for interacting with PuppetDB'
     default_subcommand 'help'
-
-    flag :v, :version, 'Show version of puppetdb cli tool.' do |_, _|
-      puts PuppetDBCLI::VERSION
-      exit 0
-    end
-
-    flag :h, :help, 'Show help for this command.' do |_, c|
-      puts c.help
-      exit 0
-    end
-
-    flag :d, :debug, 'Enable debug output.' do |_, _|
-      PuppetDBCLI.logger.enable_debug_mode
-    end
-
-    option :c, :config, 'The path to the PuppetDB CLI config', argument: :required
-
-    option nil, :urls, 'The urls of your PuppetDB instances (overrides SERVER_URLS).', argument: :required
-
-    option nil, :cacert, 'Overrides the path for the Puppet CA cert', argument: :required
-
-    option nil, :cert, 'Overrides the path for the Puppet client cert.', argument: :required
-
-    option nil, :key, 'Overrides the path for the Puppet client private key.', argument: :required
-
-    option nil, :token, 'Overrides the path for the RBAC token (PE only).', argument: :required
   end
 
   require 'puppetdb_cli/query'

--- a/lib/puppetdb_cli/db.rb
+++ b/lib/puppetdb_cli/db.rb
@@ -5,16 +5,13 @@
 # This subcommand has no functionalty other than --help. It's purpose is to contain
 # subcommands for compatibility with usage as 'puppet db'.
 module PuppetDBCLI
-  @db_cmd = @base_cmd.define_command do
-    name 'db'
-    usage 'db [options] <subcommand>'
-    summary 'manage PuppetDB administrative tasks'
-    default_subcommand 'help'
+  @db_cmd = @base_cmd.define_command do |dsl|
+    dsl.name 'db'
+    dsl.usage 'db [options] <subcommand>'
+    dsl.summary 'manage PuppetDB administrative tasks'
+    dsl.default_subcommand 'help'
 
-    flag :h, :help, 'Show help for this command.' do |_, c|
-      puts c.help
-      exit 0
-    end
+    PuppetDBCLI::Utils::DefaultOptions.include_default_options(dsl)
   end
 
   @db_cmd.add_command Cri::Command.new_basic_help

--- a/lib/puppetdb_cli/query.rb
+++ b/lib/puppetdb_cli/query.rb
@@ -6,18 +6,14 @@ require 'json'
 #
 # The query command submits queries to /pdb/query/v4
 module PuppetDBCLI
-  @query_cmd = @base_cmd.define_command do
-    name 'query'
-    usage 'query [options] <query>'
-    summary 'Query puppetdb with AST or PQL'
+  @query_cmd = @base_cmd.define_command do |dsl|
+    dsl.name 'query'
+    dsl.usage 'query [options] <query>'
+    dsl.summary 'Query puppetdb with AST or PQL'
 
-    flag :h, :help, 'Show help for this command.' do |_, c|
-      c.add_command Cri::Command.new_basic_help
-      puts c.help
-      exit 0
-    end
+    PuppetDBCLI::Utils::DefaultOptions.include_default_options(dsl)
 
-    run do |opts, args, cmd|
+    dsl.run do |opts, args, cmd|
       PuppetDBCLI::Utils.log_command_start cmd.name, opts, args
 
       if args.count.zero?

--- a/lib/puppetdb_cli/utils.rb
+++ b/lib/puppetdb_cli/utils.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'puppetdb_cli/utils/default_options'
+
 # Utils for PuppetDBCLI
 #
 # Primarily used for interaction with the PuppetDB::Client

--- a/lib/puppetdb_cli/utils/default_options.rb
+++ b/lib/puppetdb_cli/utils/default_options.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PuppetDBCLI
+  module Utils
+    # Defaults for puppet-query and puppet-db
+    module DefaultOptions
+      def self.include_default_options(dsl)
+        dsl.flag :v, :version, 'Show version of puppetdb cli tool.' do |_, _|
+          puts PuppetDBCLI::VERSION
+          exit 0
+        end
+
+        dsl.flag :h, :help, 'Show help for this command.' do |_, c|
+          puts c.help
+          exit 0
+        end
+
+        dsl.flag :d, :debug, 'Enable debug output.' do |_, _|
+          PuppetDBCLI.logger.enable_debug_mode
+        end
+
+        dsl.option :c, :config, 'The path to the PuppetDB CLI config', argument: :required
+
+        dsl.option nil, :urls, 'The urls of your PuppetDB instances (overrides SERVER_URLS).', argument: :required
+
+        dsl.option nil, :cacert, 'Overrides the path for the Puppet CA cert', argument: :required
+
+        dsl.option nil, :cert, 'Overrides the path for the Puppet client cert.', argument: :required
+
+        dsl.option nil, :key, 'Overrides the path for the Puppet client private key.', argument: :required
+
+        dsl.option nil, :token, 'Overrides the path for the RBAC token (PE only).', argument: :required
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.before :each do
+    PuppetDBCLI.logger.level = ::Logger::INFO
+  end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/unit/puppetdb_cli/db_spec.rb
+++ b/spec/unit/puppetdb_cli/db_spec.rb
@@ -5,6 +5,23 @@ require 'spec_helper'
 RSpec.describe 'Running `puppetdb db`' do
   subject { PuppetDBCLI.instance_variable_get(:@db_cmd) }
 
+  context 'when given the debug flag' do
+    it 'enables debug mode' do
+      expect(PuppetDBCLI.logger).to receive(:enable_debug_mode).and_call_original
+      expect($stderr).to receive(:write).with(a_string_matching(/\[.*\] DEBUG -- Debug mode enabled/))
+      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*SUBCOMMANDS.*OPTIONS/m))
+      PuppetDBCLI.run(['db', '--debug'])
+    end
+  end
+
+  context 'when invoking version' do
+    it 'prints the version' do
+      expect($stdout).to receive(:puts).with(PuppetDBCLI::VERSION)
+
+      expect { PuppetDBCLI.run(['db', '--version']) }.to exit_zero
+    end
+  end
+
   context 'when no arguments or options are provided' do
     it 'outputs basic help' do
       expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*COMMANDS.*OPTIONS/m))
@@ -15,7 +32,7 @@ RSpec.describe 'Running `puppetdb db`' do
 
   context 'when invoking help' do
     it 'outputs basic help' do
-      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*COMMANDS.*OPTIONS/m))
+      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*SUBCOMMANDS.*OPTIONS/m))
 
       expect { PuppetDBCLI.run(['db', '--help']) }.to exit_zero
     end

--- a/spec/unit/puppetdb_cli/query_spec.rb
+++ b/spec/unit/puppetdb_cli/query_spec.rb
@@ -13,9 +13,26 @@ RSpec.describe 'Running `puppetdb query`' do
     end
   end
 
+  context 'when given the debug flag' do
+    it 'enables debug mode' do
+      expect(PuppetDBCLI.logger).to receive(:enable_debug_mode).and_call_original
+      expect($stderr).to receive(:write).with(a_string_matching(/\[.*\] DEBUG -- Debug mode enabled/))
+      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*OPTIONS/m))
+      expect { PuppetDBCLI.run(['query', '--debug', '--help']) }.to exit_zero
+    end
+  end
+
+  context 'when invoking version' do
+    it 'prints the version' do
+      expect($stdout).to receive(:puts).with(PuppetDBCLI::VERSION)
+
+      expect { PuppetDBCLI.run(['query', '--version']) }.to exit_zero
+    end
+  end
+
   context 'when invoking help' do
     it 'outputs basic help' do
-      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*COMMANDS.*OPTIONS/m))
+      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*OPTIONS/m))
 
       expect { PuppetDBCLI.run(['query', '--help']) }.to exit_zero
     end

--- a/spec/unit/puppetdb_cli_spec.rb
+++ b/spec/unit/puppetdb_cli_spec.rb
@@ -6,29 +6,4 @@ RSpec.describe PuppetDBCLI do
   it 'has a version number' do
     expect(PuppetDBCLI::VERSION).not_to be nil
   end
-
-  context 'when invoking help' do
-    it 'outputs basic help' do
-      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS/m))
-
-      expect { described_class.run(['--help']) }.to exit_zero
-    end
-  end
-
-  context 'when given the debug flag' do
-    it 'enables debug mode' do
-      expect(PuppetDBCLI.logger).to receive(:enable_debug_mode).and_call_original
-      expect($stderr).to receive(:write).with(a_string_matching(/\[.*\] DEBUG -- Debug mode enabled/))
-      expect($stdout).to receive(:puts).with(a_string_matching(/NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS/m))
-      described_class.run(['--debug'])
-    end
-  end
-
-  context 'when invoking version' do
-    it 'prints the version' do
-      expect($stdout).to receive(:puts).with(PuppetDBCLI::VERSION)
-
-      expect { described_class.run(['--version']) }.to exit_zero
-    end
-  end
 end


### PR DESCRIPTION
Before they resided in the top level 'puppet' command, which created
confusing help output with the message "Options for Puppet" when the
options would never actually reach what end users would think of as the
puppet command.

They've now been added to the puppet-query and puppet-db commands
for more sane help output.