### PR TITLE
(maint) Stop hard-coding enterprise.d.p.n for beaker_pe_dir

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -36,8 +36,8 @@ task :acceptance do
   #fail if SHA not present
   fail "SHA must be set in order to setup repositories!!!" if !ENV['SHA']
 
-  # hardcode the pe_dir into the repo instead of the jenkins job
-  ENV['BEAKER_PE_DIR'] = "http://enterprise.delivery.puppetlabs.net/#{ENV['PE_FAMILY']}/ci-ready" unless ENV["BEAKER_TYPE"] == 'foss'
+  default_pe_dir = "https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/#{ENV['PE_FAMILY']}/ci-ready"
+  ENV['BEAKER_PE_DIR'] ||= default_pe_dir unless ENV["BEAKER_TYPE"] == 'foss'
 
   config = ENV["BEAKER_CONFIG"] || 'hosts.cfg'
   preserve_hosts = ENV["BEAKER_PRESERVEHOSTS"] || 'onfail'


### PR DESCRIPTION
Now that we are using artifactory (and could change in the future), stop hard-coding BEAKER_PE_DIR and respect the environment variable so that this can be set in CI pipelines.