### PR TITLE
(maint) Pin rust to older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: rust
 matrix:
     fast_finish: true
     include:
-        - rust: nightly
-        - rust: beta
-        - rust: stable
+        # Version in appveyor
+        - rust: 1.23.0
+        # Version we build and ship pe-client-tools with
+        - rust: 1.18.0
 
 sudo: false
 


### PR DESCRIPTION
Newer versions of rust find some bad code in dependencies. This commit pins to older compiler versions we use to build and ship the rust components in pe-client-tools.