### PR TITLE
(maint) Silence usage message on ArgError

### DIFF
--- a/cmd/puppet-db/export.go
+++ b/cmd/puppet-db/export.go
@@ -22,14 +22,14 @@ var exportCmd = &cobra.Command{
 		}
 		return nil
 	},
-	RunE: executeExportCommand,
+	Run: executeExportCommand,
 }
 
 func init() {
 	cmd.RootCmd.AddCommand(exportCmd)
 }
 
-func executeExportCommand(cmd *cobra.Command, args []string) error {
+func executeExportCommand(cmd *cobra.Command, args []string) {
 	anonymizationProfile, _ := cmd.Flags().GetString("anon")
 
 	url := viper.GetStringSlice("urls")[0]
@@ -49,7 +49,8 @@ func executeExportCommand(cmd *cobra.Command, args []string) error {
 	_, err := puppetDb.GetExportFile(filePath, anonymizationProfile)
 
 	if _, ok := err.(*api.ArgError); ok {
-		return err
+		log.Error(err.Error())
+		os.Exit(1)
 	}
 
 	if err != nil {
@@ -57,5 +58,4 @@ func executeExportCommand(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	fmt.Println("Wrote archive to \"", filePath, "\"")
-	return nil
 }

--- a/cmd/puppet-db/import.go
+++ b/cmd/puppet-db/import.go
@@ -22,14 +22,14 @@ var importCmd = &cobra.Command{
 		}
 		return nil
 	},
-	RunE: executeImportCommand,
+	Run: executeImportCommand,
 }
 
 func init() {
 	cmd.RootCmd.AddCommand(importCmd)
 }
 
-func executeImportCommand(cmd *cobra.Command, args []string) error {
+func executeImportCommand(cmd *cobra.Command, args []string) {
 	url := viper.GetStringSlice("urls")[0]
 	filePath := args[0]
 
@@ -47,7 +47,8 @@ func executeImportCommand(cmd *cobra.Command, args []string) error {
 	resp, err := puppetDb.PostImportFile(filePath)
 
 	if _, ok := err.(*api.ArgError); ok {
-		return err
+		log.Error(err.Error())
+		os.Exit(1)
 	}
 
 	if err != nil {
@@ -58,5 +59,4 @@ func executeImportCommand(cmd *cobra.Command, args []string) error {
 		log.Warn(fmt.Sprintf("API returned 200, but got 'ok: %t' instead of true", resp.Payload.Ok))
 	}
 	log.Info(fmt.Sprintf("Successfully imported \"%s\"", filePath))
-	return nil
 }

--- a/cmd/puppet-db/status.go
+++ b/cmd/puppet-db/status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/puppetlabs/puppetdb-cli/app"
 	"github.com/puppetlabs/puppetdb-cli/cmd"
 	"github.com/puppetlabs/puppetdb-cli/json"
+	"github.com/puppetlabs/puppetdb-cli/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -17,14 +18,14 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "status",
 	Long:  "status",
-	RunE:  executeStatusCommand,
+	Run:   executeStatusCommand,
 }
 
 func init() {
 	cmd.RootCmd.AddCommand(statusCmd)
 }
 
-func executeStatusCommand(cmd *cobra.Command, args []string) error {
+func executeStatusCommand(cmd *cobra.Command, args []string) {
 	result := make(map[string]interface{})
 
 	for _, url := range viper.GetStringSlice("urls") {
@@ -38,7 +39,8 @@ func executeStatusCommand(cmd *cobra.Command, args []string) error {
 		resp, err := puppetDb.GetStatus()
 
 		if _, ok := err.(*api.ArgError); ok {
-			return err
+			log.Error(err.Error())
+			os.Exit(1)
 		}
 
 		if err != nil {
@@ -51,5 +53,4 @@ func executeStatusCommand(cmd *cobra.Command, args []string) error {
 	}
 	//FIXME if all are errors, we should return 1
 	json.WritePayload(os.Stdout, result)
-	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -246,13 +246,19 @@ func validateGlobalFlags(cmd *cobra.Command) error {
 	}
 	initConfig(cfgFile)
 
-	// If the token file path is the default path, and the file does
-	// not exist, unset the flag. This is in line with the rust
-	// behavior.
+	// If the user did not supply a token file, and the default file
+	// does not exist, unset the flag. This is in line with the rust
+	// behavior. Otherwise, if a user-supplied file does not exist, we
+	// error out.
 	tokenFile := viper.GetString("token")
-	if tokenFile == getDefaultToken() {
+	if tokenFile != "" {
 		if _, err = os.Stat(tokenFile); err != nil {
-			cmd.Flags().Set("token", "")
+			if !cmd.Flags().Changed("token") {
+				cmd.Flags().Set("token", "")
+			} else {
+				log.Error(fmt.Sprintf("Cannot open token file: %s", err.Error()))
+				os.Exit(1)
+			}
 		}
 	}
 


### PR DESCRIPTION
Our CLI also shows an usage message when we threw the `ssl requires a
token...` error. Silence the usage message so it behaves like its rust
counterpart.