### PR TITLE
(CT-133) handle HTTP error 403 returning string

### DIFF
--- a/acceptance/pe/tests/query_without_permissions.rb
+++ b/acceptance/pe/tests/query_without_permissions.rb
@@ -1,0 +1,27 @@
+require 'scooter'
+require 'beaker-pe'
+
+test_name "attempt to execute query without permissions" do
+
+  teardown do
+    puppet_access_on(client, 'delete-token-file')
+  end
+
+  step 'setup a user without permissions and get token with puppet-access' do
+    console_dispatcher = Scooter::HttpDispatchers::ConsoleDispatcher.new(master)
+
+    empty_permissions = {'permissions' => []}
+    no_permissions_role = console_dispatcher.generate_role(empty_permissions)
+
+    user = console_dispatcher.generate_local_user
+    console_dispatcher.add_user_to_role(user, no_permissions_role)
+    login_with_puppet_access_on(client, user,  {:lifetime => '1d'})
+  end
+
+  step 'check that puppet-query fails' do
+    puppet_query_on(client, 'nodes[certname]{}', :acceptable_exit_codes => [1]) do |result|
+      assert_match("ERROR - [GET /pdb/query/v4][403] getQueryForbidden  Permission denied: User does not have permission to access PuppetDB", result.output)
+    end
+  end
+
+end

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -89,6 +89,11 @@ paths:
           schema:
             description: 'PQL parse error'
             type: string
+        403:
+          description: Permission denied response
+          schema:
+            description: 'Permission denied'
+            type: string
         default:
           description: Unexpected error
           schema:

--- a/api/client/operations/get_query_responses.go
+++ b/api/client/operations/get_query_responses.go
@@ -35,6 +35,12 @@ func (o *GetQueryReader) ReadResponse(response runtime.ClientResponse, consumer 
 			return nil, err
 		}
 		return nil, result
+	case 403:
+		result := NewGetQueryForbidden()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		result := NewGetQueryDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -100,6 +106,37 @@ func (o *GetQueryBadRequest) GetPayload() string {
 }
 
 func (o *GetQueryBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetQueryForbidden creates a GetQueryForbidden with default headers values
+func NewGetQueryForbidden() *GetQueryForbidden {
+	return &GetQueryForbidden{}
+}
+
+/*GetQueryForbidden handles this case with default header values.
+
+Permission denied response
+*/
+type GetQueryForbidden struct {
+	Payload string
+}
+
+func (o *GetQueryForbidden) Error() string {
+	return fmt.Sprintf("[GET /pdb/query/v4][%d] getQueryForbidden  %+v", 403, o.Payload)
+}
+
+func (o *GetQueryForbidden) GetPayload() string {
+	return o.Payload
+}
+
+func (o *GetQueryForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {


### PR DESCRIPTION
 In case of insufficient permissions of a user, a string
 message is returned while puppet-query expect an error json.

 Model was updated to handle string response for HTTP error 403.