### PR TITLE
(PE-31359) disable SAN check enforcing in puppet-query

### DIFF
--- a/cmd/puppet-query/main.go
+++ b/cmd/puppet-query/main.go
@@ -16,6 +16,8 @@ func init() {
 }
 
 func main() {
+	os.Setenv("GODEBUG", "x509ignoreCN=0")
+
 	if err := cmd.Execute(Version); err != nil {
 		log.Error(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Whe compiling with go 1.15, SAN enforcing is enabled by default and
can be disabled by adding the value x509ignoreCN=0 to the GODEBUG

https://golang.org/doc/go1.15#commonname